### PR TITLE
Add TelegramUser serialization tests

### DIFF
--- a/TELEGRAM_API.md
+++ b/TELEGRAM_API.md
@@ -470,7 +470,7 @@ Check off types and structures as they are implemented:
 - [ ] UniqueGiftModel
 - [ ] UniqueGiftSymbol
 - [ ] Update
-- [ ] User
+- [x] User
 - [ ] UserChatBoosts
 - [ ] UserProfilePhotos
 - [ ] UserShared

--- a/src/core/types/user.rs
+++ b/src/core/types/user.rs
@@ -1,7 +1,32 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Represents a Telegram user in the context of a Mini App.
-#[derive(Clone, Debug, Deserialize)]
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_json::{from_str, to_string};
+/// use telegram_webapp_sdk::core::types::user::TelegramUser;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let user = TelegramUser {
+///     id: 1,
+///     is_bot: Some(false),
+///     first_name: "Alice".into(),
+///     last_name: Some("Smith".into()),
+///     username: Some("alice".into()),
+///     language_code: Some("en".into()),
+///     is_premium: Some(true),
+///     added_to_attachment_menu: Some(false),
+///     allows_write_to_pm: Some(true),
+///     photo_url: Some("https://example.com/photo.jpg".into())
+/// };
+/// let json = to_string(&user)?;
+/// let parsed: TelegramUser = from_str(&json)?;
+/// assert_eq!(parsed.id, user.id);
+/// # Ok(()) }
+/// ```
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TelegramUser {
     /// Unique Telegram user or bot ID (64-bit unsigned integer).
     pub id: u64,
@@ -32,4 +57,38 @@ pub struct TelegramUser {
 
     /// Profile photo URL (JPEG or SVG), if available.
     pub photo_url: Option<String>
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_str, to_string};
+
+    use super::*;
+
+    #[test]
+    fn serialize_user() {
+        let user = TelegramUser {
+            id: 42,
+            is_bot: Some(false),
+            first_name: "Bob".into(),
+            last_name: None,
+            username: Some("bob".into()),
+            language_code: Some("en".into()),
+            is_premium: Some(false),
+            added_to_attachment_menu: Some(false),
+            allows_write_to_pm: Some(true),
+            photo_url: Some("https://example.com/avatar.jpg".into())
+        };
+        let json = to_string(&user).unwrap();
+        assert!(json.contains("Bob"));
+        let parsed: TelegramUser = from_str(&json).unwrap();
+        assert_eq!(parsed.id, user.id);
+    }
+
+    #[test]
+    fn deserialize_user_missing_required() {
+        let json = r#"{"first_name":"John"}"#; // missing `id`
+        let res: Result<TelegramUser, _> = from_str(json);
+        assert!(res.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- derive `Serialize` for `TelegramUser` and document with example
- add unit tests validating user JSON serialization and required fields
- check off `User` in API coverage list

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets --workspace --exclude demo`
- `cargo test --all --exclude demo`
- `cargo doc --no-deps --workspace --exclude demo`


------
https://chatgpt.com/codex/tasks/task_e_68c27cca3b1c832b8f1ecc3833e3ab82