### PR TITLE
Add back button and viewport helpers

### DIFF
--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -1,5 +1,5 @@
 use js_sys::{Function, Object, Reflect};
-use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::window;
 
 /// Safe wrapper around `window.Telegram.WebApp`
@@ -160,8 +160,45 @@ impl TelegramWebApp {
         func.call1(&self.inner, arg).ok()?;
         Some(())
     }
+
+    /// Returns the current viewport height in pixels.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// let _ = app.viewport_height();
+    /// ```
     pub fn viewport_height(&self) -> Option<f64> {
         Reflect::get(&self.inner, &"viewportHeight".into())
+            .ok()?
+            .as_f64()
+    }
+
+    /// Returns the current viewport width in pixels.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// let _ = app.viewport_width();
+    /// ```
+    pub fn viewport_width(&self) -> Option<f64> {
+        Reflect::get(&self.inner, &"viewportWidth".into())
+            .ok()?
+            .as_f64()
+    }
+
+    /// Returns the stable viewport height in pixels.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// let _ = app.viewport_stable_height();
+    /// ```
+    pub fn viewport_stable_height(&self) -> Option<f64> {
+        Reflect::get(&self.inner, &"viewportStableHeight".into())
             .ok()?
             .as_f64()
     }
@@ -194,5 +231,104 @@ impl TelegramWebApp {
                 .ok()
             });
         cb.forget();
+    }
+
+    /// Registers a callback for the native back button.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// app.set_back_button_callback(|| {});
+    /// ```
+    pub fn set_back_button_callback<F>(&self, callback: F)
+    where
+        F: 'static + Fn()
+    {
+        if let Ok(back_button) = Reflect::get(&self.inner, &"BackButton".into()) {
+            let cb = Closure::<dyn FnMut()>::new(callback);
+            let _ = Reflect::get(&back_button, &"onClick".into())
+                .ok()
+                .and_then(|f| f.dyn_ref::<Function>().cloned())
+                .and_then(|f| f.call1(&back_button, cb.as_ref().unchecked_ref()).ok());
+            cb.forget();
+        }
+    }
+
+    /// Returns whether the native back button is visible.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// let _ = app.is_back_button_visible();
+    /// ```
+    pub fn is_back_button_visible(&self) -> bool {
+        Reflect::get(&self.inner, &"BackButton".into())
+            .ok()
+            .and_then(|bb| Reflect::get(&bb, &"isVisible".into()).ok())
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[allow(dead_code)]
+    fn setup_webapp() -> Object {
+        let win = window().unwrap();
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn viewport_dimensions() {
+        let webapp = setup_webapp();
+        let _ = Reflect::set(&webapp, &"viewportWidth".into(), &JsValue::from_f64(320.0));
+        let _ = Reflect::set(
+            &webapp,
+            &"viewportStableHeight".into(),
+            &JsValue::from_f64(480.0)
+        );
+        let app = TelegramWebApp::instance().unwrap();
+        assert_eq!(app.viewport_width(), Some(320.0));
+        assert_eq!(app.viewport_stable_height(), Some(480.0));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn back_button_visibility_and_callback() {
+        let webapp = setup_webapp();
+        let back_button = Object::new();
+        let _ = Reflect::set(&webapp, &"BackButton".into(), &back_button);
+        let _ = Reflect::set(&back_button, &"isVisible".into(), &JsValue::TRUE);
+
+        let on_click = Function::new_with_args("cb", "cb();");
+        let _ = Reflect::set(&back_button, &"onClick".into(), &on_click);
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = Rc::clone(&called);
+
+        let app = TelegramWebApp::instance().unwrap();
+        assert!(app.is_back_button_visible());
+        app.set_back_button_callback(move || {
+            called_clone.set(true);
+        });
+        assert!(called.get());
     }
 }


### PR DESCRIPTION
## Summary
- add viewport width and stable height getters
- expose back button callback and visibility helpers
- cover new APIs with wasm tests

## Testing
- `cargo +nightly fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all --exclude demo`
- `cargo test -p telegram-webapp-sdk --target wasm32-unknown-unknown` *(fails: Exec format error)*
- `cargo doc --no-deps`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68c27d03ed40832b8a94cf1ca6c886db