### PR TITLE
feat: gate mock module behind optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,13 @@ web-sys = { version = "0.3", features = [
   "Element",
   "HtmlElement",
   "console",
-  "Navigator",
-  "Geolocation",
   "Location",
   "CssStyleDeclaration",
 ] }
 hmac-sha256 = "1.1"
 hex = "0.4"
 percent-encoding = "2.3"
-urlencoding = "2.1"
+urlencoding = { version = "2.1", optional = true }
 
 [dependencies.yew]
 version = "0.21.0"
@@ -50,6 +48,7 @@ features = ["csr"]
 default = []
 yew = ["dep:yew"]
 leptos = ["dep:leptos"]
+mock = ["dep:urlencoding"]
 
 [workspace]
 members = ["demo"]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ A Rust library for building Telegram Web Apps with an ergonomic and safe API.
 - Optional framework integrations activated via Cargo features:
   - `yew` &mdash; provides a Yew hook `use_telegram_context` for retrieving the global `TelegramContext`.
   - `leptos` &mdash; offers `provide_telegram_context` to inject the `TelegramContext` into the Leptos reactive system.
+- `mock` &mdash; injects a configurable mock `Telegram.WebApp` environment for local development.
 - Basic Bot API type definitions including `WebAppInfo`, `WebAppData`,
   `SentWebAppMessage`, `WebhookInfo`, and `WriteAccessAllowed`.
 
 Enable features in `Cargo.toml`:
 
 ```toml
-telegram-webapp-sdk = { version = "0.1", features = ["yew"] }
+telegram-webapp-sdk = { version = "0.1", features = ["yew", "mock"] }
 ```
 
 ## Examples

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -18,4 +18,10 @@ web-sys = { version = "0.3", features = [
   "console",
   "Text",
 ] }
-telegram-webapp-sdk = { path = "../" }
+telegram-webapp-sdk = { path = "../", features = ["mock"] }
+
+[[bin]]
+name = "demo"
+path = "src/main.rs"
+test = false
+bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod api;
 pub mod core;
 pub mod logger;
+
+#[cfg(feature = "mock")]
 pub mod mock;
 pub mod utils;
 pub mod webapp;

--- a/src/mock/utils.rs
+++ b/src/mock/utils.rs
@@ -21,3 +21,24 @@ pub fn generate_mock_init_data(user: &MockTelegramUser, auth_date: &str, hash: &
         encoded_user, auth_date, hash
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_expected_init_data() {
+        let user = MockTelegramUser {
+            id: 1,
+            first_name: "Dev".into(),
+            ..Default::default()
+        };
+        let auth_date = "123456";
+        let hash = "hash";
+        let data = generate_mock_init_data(&user, auth_date, hash);
+
+        assert!(data.contains("user="));
+        assert!(data.contains("auth_date=123456"));
+        assert!(data.contains("hash=hash"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `mock` Cargo feature to opt in to mock Telegram environment
- streamline `web-sys` features and make urlencoding optional
- document new feature and test mock init data helper

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo clippy --features mock -- -D warnings`
- `cargo build --all-targets`
- `cargo build --all-targets --features mock`
- `cargo test --all`
- `cargo test --all --features mock`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c28b504788832b8410dea51361a8b8