### PR TITLE
Propagate launch parameter retrieval errors

### DIFF
--- a/demo/src/pages/launch_params.rs
+++ b/demo/src/pages/launch_params.rs
@@ -11,7 +11,13 @@ pub fn render_launch_params_page() {
 
     let page = PageLayout::new("Launch Parameters");
 
-    let lp = get_launch_params();
+    let lp = match get_launch_params() {
+        Ok(params) => params,
+        Err(err) => {
+            web_sys::console::error_1(&err);
+            return;
+        }
+    };
 
     let rows = vec![
         DisplayDataRow {


### PR DESCRIPTION
## Summary
- return `Result<LaunchParams, JsValue>` from `get_launch_params`
- log and exit Launch Parameters demo page when retrieval fails
- cover window absence with a wasm-bindgen test

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2939aca1c832b9b7ed92380905dd0