### PR TITLE
Add wasm-bindgen tests for events and theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+      - name: Install nightly rustfmt
+        run: rustup toolchain install nightly -c rustfmt
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: |
+          curl -L https://github.com/rustwasm/wasm-pack/releases/download/v0.12.1/wasm-pack-v0.12.1-x86_64-unknown-linux-musl.tar.gz -o wasm-pack.tar.gz
+          tar -xzf wasm-pack.tar.gz
+          sudo mv wasm-pack-v0.12.1-x86_64-unknown-linux-musl/wasm-pack /usr/local/bin/
+      - name: Format
+        run: cargo +nightly fmt -- --check
+      - name: Clippy
+        run: cargo clippy -D warnings
+      - name: Build
+        run: cargo build --all-targets
+      - name: Test
+        run: cargo test --all
+      - name: Wasm tests
+        run: wasm-pack test --headless --chrome

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -1,5 +1,5 @@
 use js_sys::{Function, Reflect};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use web_sys::window;
 
 /// Adds an event listener for Telegram.WebApp.onEvent(name, callback)
@@ -28,4 +28,49 @@ fn get_webapp_object() -> Result<JsValue, JsValue> {
     let window = window().ok_or_else(|| JsValue::from_str("no window"))?;
     let telegram = Reflect::get(&window, &JsValue::from_str("Telegram"))?;
     Reflect::get(&telegram, &JsValue::from_str("WebApp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen::{JsValue, closure::Closure};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[allow(dead_code)]
+    fn setup_webapp() -> Object {
+        let win = window().expect("window should be available");
+        let telegram = Object::new();
+        let webapp = Object::new();
+
+        // onEvent stores the callback under the event name.
+        let on_event = Function::new_with_args("name, cb", "this[name] = cb;");
+        // offEvent removes the stored callback.
+        let off_event = Function::new_with_args("name", "delete this[name];");
+
+        let _ = Reflect::set(&webapp, &"onEvent".into(), &on_event);
+        let _ = Reflect::set(&webapp, &"offEvent".into(), &off_event);
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code)]
+    fn registers_and_removes_callback() {
+        let webapp = setup_webapp();
+        let cb = Closure::wrap(Box::new(|| {}) as Box<dyn Fn()>);
+
+        on_event("test-event", &cb).expect("register callback");
+        let has = Reflect::has(&webapp, &JsValue::from_str("test-event")).unwrap();
+        assert!(has, "callback was not stored");
+
+        off_event("test-event", &cb).expect("remove callback");
+        let has_after = Reflect::has(&webapp, &JsValue::from_str("test-event")).unwrap();
+        assert!(!has_after, "callback was not removed");
+    }
 }

--- a/src/api/theme.rs
+++ b/src/api/theme.rs
@@ -17,3 +17,47 @@ pub fn get_theme_params() -> Result<TelegramThemeParams, JsValue> {
     from_value(theme_params)
         .map_err(|e| JsValue::from_str(&format!("themeParams parse error: {e}")))
 }
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Object, Reflect};
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[allow(dead_code)]
+    fn setup_webapp() -> Object {
+        let win = window().expect("window should be available");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code)]
+    fn parses_valid_theme() {
+        let webapp = setup_webapp();
+        let theme = Object::new();
+        let _ = Reflect::set(&theme, &"bg_color".into(), &JsValue::from_str("#ffffff"));
+        let _ = Reflect::set(&theme, &"text_color".into(), &JsValue::from_str("#000000"));
+        let _ = Reflect::set(&webapp, &"themeParams".into(), &theme);
+
+        let params = get_theme_params().expect("theme params");
+        assert_eq!(params.bg_color.as_deref(), Some("#ffffff"));
+        assert_eq!(params.text_color.as_deref(), Some("#000000"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code)]
+    fn fails_on_invalid_data() {
+        let webapp = setup_webapp();
+        let _ = Reflect::set(&webapp, &"themeParams".into(), &JsValue::from_f64(5.0));
+        assert!(get_theme_params().is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add wasm-bindgen tests for event listener registration and removal
- cover theme parameter parsing and error handling
- run wasm tests in CI via wasm-pack

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `wasm-pack test --headless --firefox` *(fails: Network unreachable (os error 101))*

------
https://chatgpt.com/codex/tasks/task_e_68c293a302bc832ba552d473cd1b8256