### PR TITLE
Add wasm tests for location API

### DIFF
--- a/src/api/location.rs
+++ b/src/api/location.rs
@@ -1,5 +1,5 @@
 use js_sys::{Function, Reflect};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use web_sys::window;
 
 /// Calls Telegram.WebApp.requestLocation()
@@ -52,4 +52,116 @@ fn webapp_object() -> Result<JsValue, JsValue> {
     let window = window().ok_or_else(|| JsValue::from_str("no window"))?;
     let tg = Reflect::get(&window, &JsValue::from_str("Telegram"))?;
     Reflect::get(&tg, &JsValue::from_str("WebApp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen::{JsValue, closure::Closure};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[allow(dead_code)]
+    fn setup_webapp() -> Object {
+        let win = window().expect("window should be available");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn request_location_ok() {
+        let webapp = setup_webapp();
+        let func = Function::new_no_args("this.called = true;");
+        let _ = Reflect::set(&webapp, &"requestLocation".into(), &func);
+        assert!(request_location().is_ok());
+        assert!(
+            Reflect::get(&webapp, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn request_location_err() {
+        let _ = setup_webapp();
+        assert!(request_location().is_err());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn check_location_access_ok() {
+        let webapp = setup_webapp();
+        let func = Function::new_no_args("this.called = true;");
+        let _ = Reflect::set(&webapp, &"checkLocationAccess".into(), &func);
+        assert!(check_location_access().is_ok());
+        assert!(
+            Reflect::get(&webapp, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn check_location_access_err() {
+        let _ = setup_webapp();
+        assert!(check_location_access().is_err());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn open_location_settings_ok() {
+        let webapp = setup_webapp();
+        let func = Function::new_no_args("this.called = true;");
+        let _ = Reflect::set(&webapp, &"openLocationSettings".into(), &func);
+        assert!(open_location_settings().is_ok());
+        assert!(
+            Reflect::get(&webapp, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn open_location_settings_err() {
+        let _ = setup_webapp();
+        assert!(open_location_settings().is_err());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code)]
+    fn registers_location_requested_callback() {
+        let webapp = setup_webapp();
+        let on_event = Function::new_with_args("name, cb", "this[name] = cb;");
+        let _ = Reflect::set(&webapp, &"onEvent".into(), &on_event);
+        let cb = Closure::wrap(Box::new(|| {}) as Box<dyn Fn()>);
+        on_location_requested(&cb).expect("register callback");
+        let has = Reflect::has(&webapp, &JsValue::from_str("locationRequested")).unwrap();
+        assert!(has);
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code)]
+    fn registers_location_allowed_callback() {
+        let webapp = setup_webapp();
+        let on_event = Function::new_with_args("name, cb", "this[name] = cb;");
+        let _ = Reflect::set(&webapp, &"onEvent".into(), &on_event);
+        let cb = Closure::wrap(Box::new(|| {}) as Box<dyn Fn()>);
+        on_location_allowed(&cb).expect("register callback");
+        let has = Reflect::has(&webapp, &JsValue::from_str("locationAllowed")).unwrap();
+        assert!(has);
+    }
 }

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -193,14 +193,6 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.MainButton.show()`
-    pub fn show_main_button(&self) {
-        if let Ok(main_button) = Reflect::get(&self.inner, &"MainButton".into()) {
-            let _ = Reflect::get(&main_button, &"show".into())
-                .ok()
-                .and_then(|f| f.dyn_ref::<Function>().cloned())
-                .and_then(|f| f.call0(&main_button).ok());
-        }
     /// Call `WebApp.MainButton.show()`.
     ///
     /// # Errors
@@ -238,9 +230,6 @@ impl TelegramWebApp {
             .inspect_err(|_| logger::error("MainButton.hide call failed"))?;
         Ok(())
     }
-    /// Call `WebApp.ready()`
-    pub fn ready(&self) {
-        let _ = self.call0("ready");
     /// Call `WebApp.ready()`.
     ///
     /// # Errors
@@ -326,9 +315,6 @@ impl TelegramWebApp {
             .inspect_err(|_| logger::error("MainButton.setTextColor call failed"))?;
         Ok(())
     }
-
-    /// Set callback for MainButton.onClick()
-    pub fn set_main_button_callback<F>(&self, callback: F)
 
     /// Set callback for `MainButton.onClick()`.
     ///


### PR DESCRIPTION
## Summary
- add wasm-bindgen tests for location API covering success/failure and callback registration
- fix duplicate webapp methods to allow building

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c298737fd4832bb6a1c06ad028ea44