### PR TITLE
Refactor viewport expansion and add wasm tests

### DIFF
--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -193,14 +193,6 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.MainButton.show()`
-    pub fn show_main_button(&self) {
-        if let Ok(main_button) = Reflect::get(&self.inner, &"MainButton".into()) {
-            let _ = Reflect::get(&main_button, &"show".into())
-                .ok()
-                .and_then(|f| f.dyn_ref::<Function>().cloned())
-                .and_then(|f| f.call0(&main_button).ok());
-        }
     /// Call `WebApp.MainButton.show()`.
     ///
     /// # Errors
@@ -238,9 +230,6 @@ impl TelegramWebApp {
             .inspect_err(|_| logger::error("MainButton.hide call failed"))?;
         Ok(())
     }
-    /// Call `WebApp.ready()`
-    pub fn ready(&self) {
-        let _ = self.call0("ready");
     /// Call `WebApp.ready()`.
     ///
     /// # Errors
@@ -326,9 +315,6 @@ impl TelegramWebApp {
             .inspect_err(|_| logger::error("MainButton.setTextColor call failed"))?;
         Ok(())
     }
-
-    /// Set callback for MainButton.onClick()
-    pub fn set_main_button_callback<F>(&self, callback: F)
 
     /// Set callback for `MainButton.onClick()`.
     ///


### PR DESCRIPTION
## Summary
- return `Result<(), JsValue>` from `expand_viewport` and propagate JS errors
- add wasm-bindgen tests for viewport expansion success and failure
- remove outdated duplicate methods in `webapp.rs`

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c298730e44832bb7d151659921814d