### PR TITLE
Add event handle management for callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ let _ = open_contact();
 
 These calls require the user's explicit permission before any information is shared.
 
+## Event callbacks
+
+Callback registration methods return an `EventHandle` for later deregistration.
+
+```rust,no_run
+use telegram_webapp_sdk::webapp::TelegramWebApp;
+let app = TelegramWebApp::instance().unwrap();
+let handle = app.on_event("my_event", |value| {
+    let _ = value;
+}).unwrap();
+app.off_event(handle).unwrap();
+```
+
 ## Haptic feedback
 
 Trigger device vibrations through Telegram's [HapticFeedback](https://core.telegram.org/bots/webapps#hapticfeedback) API:


### PR DESCRIPTION
## Summary
- introduce `EventHandle` for managing Telegram callback lifetimes
- allow deregistering callbacks via `off_event`, `remove_main_button_callback`, and `remove_back_button_callback`
- document and test registration/removal of callback handlers

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c298704f20832b8d06160dbfeffffa