### PR TITLE
Add init data validation utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,21 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bincode"
@@ -254,6 +266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-str"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +347,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +394,16 @@ dependencies = [
  "telegram-webapp-sdk",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -388,6 +443,30 @@ name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -437,6 +516,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1336,7 +1421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38acbf32649a4b127c8d4ccaed8fb388e19a746430a0ea8f8160e51e28c36e2d"
 dependencies = [
  "any_spawner",
- "base64",
+ "base64 0.22.1",
  "codee",
  "futures",
  "hydration_context",
@@ -1580,6 +1665,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1835,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "reactive_graph"
@@ -2002,7 +2106,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4efa7bb741386fb31a68269c81b1469c917d9adb1f4102a2d2684f11e3235389"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "const-str",
  "const_format",
@@ -2072,6 +2176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,10 +2206,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2180,6 +2309,8 @@ dependencies = [
 name = "telegram-webapp-sdk"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.7",
+ "ed25519-dalek",
  "hex",
  "hmac-sha256",
  "js-sys",
@@ -2190,6 +2321,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "serde_urlencoded",
+ "thiserror 2.0.16",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -2850,6 +2982,12 @@ dependencies = [
  "syn 2.0.106",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ web-sys = { version = "0.3", features = [
 hmac-sha256 = "1.1"
 hex = "0.4"
 percent-encoding = "2.3"
+base64 = "0.21"
+ed25519-dalek = "2"
+thiserror = "2"
 urlencoding = { version = "2.1", optional = true }
 
 [dependencies.yew]

--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ selection_changed()?;
 # Ok::<(), wasm_bindgen::JsValue>(())
 ```
 
+## Init data validation
+
+Validate the integrity of the `Telegram.WebApp.initData` payload on the server:
+
+```rust
+use telegram_webapp_sdk::utils::validate_init_data::{verify_hmac_sha256, verify_ed25519};
+
+let bot_token = "123456:ABC";
+let query = "user=alice&auth_date=1&hash=48f4c0e9d3dd46a5734bf2c5d4df9f4ec52a3cd612f6482a7d2c68e84e702ee2";
+verify_hmac_sha256(query, bot_token)?;
+
+// For Ed25519-signed data
+# use ed25519_dalek::{Signer, SigningKey};
+# let sk = SigningKey::from_bytes(&[1u8;32]);
+# let pk = sk.verifying_key();
+# let sig = sk.sign(b"a=1\nb=2");
+# let init_data = format!("a=1&b=2&signature={}", base64::encode(sig.to_bytes()));
+verify_ed25519(&init_data, pk.as_bytes())?;
+
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 ## API coverage
 
 See [WEBAPP_API.md](./WEBAPP_API.md) for a checklist of supported Telegram WebApp JavaScript API methods and features.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,1 +1,2 @@
 pub mod check_env;
+pub mod validate_init_data;

--- a/src/utils/validate_init_data.rs
+++ b/src/utils/validate_init_data.rs
@@ -1,0 +1,196 @@
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use hmac_sha256::{HMAC, Hash};
+use percent_encoding::percent_decode_str;
+use thiserror::Error;
+
+/// Errors that can occur when validating Telegram init data.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ValidationError {
+    /// A required field such as `hash` or `signature` was missing.
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    /// Input contained invalid percent encoding or non-UTF8 data.
+    #[error("invalid encoding in init data")]
+    InvalidEncoding,
+    /// Signature value could not be parsed from its encoding (hex or base64).
+    #[error("invalid signature encoding")]
+    InvalidSignatureEncoding,
+    /// Computed signature did not match the provided one.
+    #[error("signature mismatch")]
+    SignatureMismatch,
+    /// Provided Ed25519 public key was malformed.
+    #[error("invalid public key")]
+    InvalidPublicKey
+}
+
+/// Validates the `hash` parameter of the init data using HMAC-SHA256.
+///
+/// The `init_data` string must be the exact value of
+/// `Telegram.WebApp.initData`. The function derives a secret key from the
+/// provided bot token and checks that the `hash` parameter matches the expected
+/// HMAC-SHA256.
+///
+/// # Errors
+/// Returns [`ValidationError`] if parsing fails or the hash does not match.
+///
+/// # Examples
+/// ```
+/// use hmac_sha256::{HMAC, Hash};
+/// use telegram_webapp_sdk::utils::validate_init_data::verify_hmac_sha256;
+/// let token = "123456:ABC";
+/// let check_string = "auth_date=1\nuser=alice";
+/// let secret = Hash::hash(format!("WebAppData{token}").as_bytes());
+/// let hash = hex::encode(HMAC::mac(check_string.as_bytes(), secret));
+/// let init_data = format!("auth_date=1&user=alice&hash={hash}");
+/// assert!(verify_hmac_sha256(&init_data, token).is_ok());
+/// ```
+pub fn verify_hmac_sha256(init_data: &str, bot_token: &str) -> Result<(), ValidationError> {
+    let (check_string, hash) = extract_check_string(init_data, "hash")?;
+
+    let secret_key = Hash::hash(format!("WebAppData{bot_token}").as_bytes());
+    let expected = HMAC::mac(check_string.as_bytes(), secret_key);
+    let expected_hex = hex::encode(expected);
+
+    if expected_hex == hash {
+        Ok(())
+    } else {
+        Err(ValidationError::SignatureMismatch)
+    }
+}
+
+/// Validates the `signature` parameter of the init data using Ed25519.
+///
+/// The `init_data` string must include a `signature` parameter encoded in
+/// Base64. All other parameters are combined into the data check string
+/// according to Telegram's specification and verified against the provided
+/// Ed25519 public key.
+///
+/// # Errors
+/// Returns [`ValidationError`] if parsing fails or the signature does not
+/// verify.
+///
+/// # Examples
+/// ```
+/// use ed25519_dalek::{Signer, SigningKey};
+/// use telegram_webapp_sdk::utils::validate_init_data::verify_ed25519;
+///
+/// // generate test key
+/// let sk = SigningKey::from_bytes(&[1u8; 32]);
+/// let pk = sk.verifying_key();
+/// let message = "a=1\nb=2";
+/// let sig = sk.sign(message.as_bytes());
+/// let init_data = format!("a=1&b=2&signature={}", base64::encode(sig.to_bytes()));
+/// assert!(verify_ed25519(&init_data, pk.as_bytes()).is_ok());
+/// ```
+pub fn verify_ed25519(init_data: &str, public_key: &[u8; 32]) -> Result<(), ValidationError> {
+    let (check_string, signature_b64) = extract_check_string(init_data, "signature")?;
+
+    let sig_bytes = BASE64_STANDARD
+        .decode(signature_b64)
+        .map_err(|_| ValidationError::InvalidSignatureEncoding)?;
+    let signature = Signature::from_slice(&sig_bytes)
+        .map_err(|_| ValidationError::InvalidSignatureEncoding)?;
+    let verifying_key =
+        VerifyingKey::from_bytes(public_key).map_err(|_| ValidationError::InvalidPublicKey)?;
+
+    verifying_key
+        .verify(check_string.as_bytes(), &signature)
+        .map_err(|_| ValidationError::SignatureMismatch)
+}
+
+fn extract_check_string(
+    init_data: &str,
+    signature_field: &'static str
+) -> Result<(String, String), ValidationError> {
+    let mut data: Vec<(String, String)> = Vec::new();
+    let mut signature: Option<String> = None;
+
+    for pair in init_data.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        let key = parts.next().ok_or(ValidationError::InvalidEncoding)?;
+        let value = parts.next().ok_or(ValidationError::InvalidEncoding)?;
+        let decoded = percent_decode_str(value)
+            .decode_utf8()
+            .map_err(|_| ValidationError::InvalidEncoding)?
+            .to_string();
+        if key == signature_field {
+            signature = Some(decoded);
+        } else {
+            data.push((key.to_string(), decoded));
+        }
+    }
+
+    let signature = signature.ok_or(ValidationError::MissingField(signature_field))?;
+
+    data.sort_by(|a, b| a.0.cmp(&b.0));
+    let check_string = data
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Ok((check_string, signature))
+}
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::{Signer, SigningKey};
+
+    use super::*;
+
+    #[test]
+    fn hmac_validates() {
+        let bot_token = "123456:ABC";
+        let secret_key = Hash::hash(format!("WebAppData{bot_token}").as_bytes());
+        let check_string = "a=1\nb=2";
+        let expected = HMAC::mac(check_string.as_bytes(), secret_key);
+        let hash = hex::encode(expected);
+        let query = format!("a=1&b=2&hash={hash}");
+        assert!(verify_hmac_sha256(&query, bot_token).is_ok());
+    }
+
+    #[test]
+    fn hmac_rejects_modified_data() {
+        let bot_token = "123456:ABC";
+        let secret_key = Hash::hash(format!("WebAppData{bot_token}").as_bytes());
+        let check_string = "a=1\nb=2";
+        let expected = HMAC::mac(check_string.as_bytes(), secret_key);
+        let hash = hex::encode(expected);
+        // tamper with data
+        assert_eq!(
+            verify_hmac_sha256(&format!("a=1&b=3&hash={hash}"), bot_token),
+            Err(ValidationError::SignatureMismatch)
+        );
+    }
+
+    #[test]
+    fn ed25519_validates() {
+        let sk = SigningKey::from_bytes(&[42u8; 32]);
+        let pk = sk.verifying_key();
+        let message = "a=1\nb=2";
+        let sig = sk.sign(message.as_bytes());
+        let init_data = format!(
+            "a=1&b=2&signature={}",
+            BASE64_STANDARD.encode(sig.to_bytes())
+        );
+        assert!(verify_ed25519(&init_data, pk.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn ed25519_rejects_bad_signature() {
+        let sk = SigningKey::from_bytes(&[42u8; 32]);
+        let pk = sk.verifying_key();
+        let message = "a=1\nb=2";
+        let sig = sk.sign(message.as_bytes());
+        // modify data
+        let tampered = format!(
+            "a=1&b=3&signature={}",
+            BASE64_STANDARD.encode(sig.to_bytes())
+        );
+        assert_eq!(
+            verify_ed25519(&tampered, pk.as_bytes()),
+            Err(ValidationError::SignatureMismatch)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `validate_init_data` utility for verifying Telegram WebApp init data via HMAC-SHA256 or Ed25519
- document init data validation and expose utility module
- cover validation logic with unit tests and examples

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2a7ea4544832bbc1daa43d1670de6