### PR TITLE
Add fullscreen and orientation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ let handle = app.on_event("my_event", |value| {
 app.off_event(handle).unwrap();
 ```
 
+## Fullscreen and orientation
+
+Control the Mini App display and screen orientation:
+
+```rust,no_run
+use telegram_webapp_sdk::webapp::TelegramWebApp;
+let app = TelegramWebApp::instance().unwrap();
+app.request_fullscreen().unwrap();
+app.lock_orientation("portrait").unwrap();
+// later...
+app.unlock_orientation().unwrap();
+app.exit_fullscreen().unwrap();
+```
+
 ## Haptic feedback
 
 Trigger device vibrations through Telegram's [HapticFeedback](https://core.telegram.org/bots/webapps#hapticfeedback) API:

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -85,6 +85,66 @@ impl TelegramWebApp {
         self.call0("close")
     }
 
+    /// Call `WebApp.requestFullscreen()`.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// app.request_fullscreen().unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn request_fullscreen(&self) -> Result<(), JsValue> {
+        self.call0("requestFullscreen")
+    }
+
+    /// Call `WebApp.exitFullscreen()`.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// app.exit_fullscreen().unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn exit_fullscreen(&self) -> Result<(), JsValue> {
+        self.call0("exitFullscreen")
+    }
+
+    /// Call `WebApp.lockOrientation(orientation)`.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// app.lock_orientation("portrait").unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn lock_orientation(&self, orientation: &str) -> Result<(), JsValue> {
+        self.call1("lockOrientation", &orientation.into())
+    }
+
+    /// Call `WebApp.unlockOrientation()`.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// app.unlock_orientation().unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn unlock_orientation(&self) -> Result<(), JsValue> {
+        self.call0("unlockOrientation")
+    }
+
     /// Call `WebApp.showAlert(message)`.
     ///
     /// # Errors
@@ -1073,6 +1133,94 @@ mod tests {
                 .as_deref(),
             Some("hash"),
         );
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn request_fullscreen_calls_js() {
+        let webapp = setup_webapp();
+        let called = Rc::new(Cell::new(false));
+        let called_clone = Rc::clone(&called);
+
+        let cb = Closure::<dyn FnMut()>::new(move || {
+            called_clone.set(true);
+        });
+        let _ = Reflect::set(
+            &webapp,
+            &"requestFullscreen".into(),
+            cb.as_ref().unchecked_ref()
+        );
+        cb.forget();
+
+        let app = TelegramWebApp::instance().unwrap();
+        app.request_fullscreen().unwrap();
+        assert!(called.get());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn exit_fullscreen_calls_js() {
+        let webapp = setup_webapp();
+        let called = Rc::new(Cell::new(false));
+        let called_clone = Rc::clone(&called);
+
+        let cb = Closure::<dyn FnMut()>::new(move || {
+            called_clone.set(true);
+        });
+        let _ = Reflect::set(
+            &webapp,
+            &"exitFullscreen".into(),
+            cb.as_ref().unchecked_ref()
+        );
+        cb.forget();
+
+        let app = TelegramWebApp::instance().unwrap();
+        app.exit_fullscreen().unwrap();
+        assert!(called.get());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn lock_orientation_calls_js() {
+        let webapp = setup_webapp();
+        let received = Rc::new(RefCell::new(None));
+        let rc_clone = Rc::clone(&received);
+
+        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+            *rc_clone.borrow_mut() = v.as_string();
+        });
+        let _ = Reflect::set(
+            &webapp,
+            &"lockOrientation".into(),
+            cb.as_ref().unchecked_ref()
+        );
+        cb.forget();
+
+        let app = TelegramWebApp::instance().unwrap();
+        app.lock_orientation("portrait").unwrap();
+        assert_eq!(received.borrow().as_deref(), Some("portrait"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn unlock_orientation_calls_js() {
+        let webapp = setup_webapp();
+        let called = Rc::new(Cell::new(false));
+        let called_clone = Rc::clone(&called);
+
+        let cb = Closure::<dyn FnMut()>::new(move || {
+            called_clone.set(true);
+        });
+        let _ = Reflect::set(
+            &webapp,
+            &"unlockOrientation".into(),
+            cb.as_ref().unchecked_ref()
+        );
+        cb.forget();
+
+        let app = TelegramWebApp::instance().unwrap();
+        app.unlock_orientation().unwrap();
+        assert!(called.get());
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- add request_fullscreen, exit_fullscreen, lock_orientation and unlock_orientation APIs
- document fullscreen and orientation usage
- test fullscreen and orientation helpers

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_68c2a7df868c832bb6e49caae9d8c3fc