### PR TITLE
feat: add emoji status APIs

### DIFF
--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -18,6 +18,8 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
  - [ ] shareURL
  - [ ] joinVoiceChat
  - [ ] requestWriteAccess
+ - [x] setEmojiStatus
+ - [x] requestEmojiStatusAccess
  - [x] requestContact
 - [ ] ready
 - [ ] expand
@@ -33,6 +35,8 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] shareURL
 - [x] joinVoiceChat
 - [x] requestWriteAccess
+ - [x] setEmojiStatus
+ - [x] requestEmojiStatusAccess
 - [ ] requestContact
 
 ## Objects


### PR DESCRIPTION
## Summary
- add request_emoji_status_access and set_emoji_status APIs with callbacks
- document new WebApp methods
- cover emoji status APIs with wasm tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo test --target wasm32-unknown-unknown` *(fails: driver requires chromium snap)*
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2a7e129f8832b9ed4d780bc9a2e4a