### PR TITLE
Add device and secure storage APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,6 +2192,7 @@ dependencies = [
  "serde_urlencoded",
  "urlencoding",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
  "yew",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"

--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ Persist lightweight data on the user's device:
 ```rust,no_run
 use telegram_webapp_sdk::api::device_storage::{set, get};
 
-set("theme", "dark")?;
-let value = get("theme")?;
-# Ok::<(), wasm_bindgen::JsValue>(())
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+set("theme", "dark").await?;
+let value = get("theme").await?;
+# Ok(())
+# }
 ```
 
 ## Secure storage
@@ -124,9 +126,11 @@ Store sensitive data encrypted and restorable:
 ```rust,no_run
 use telegram_webapp_sdk::api::secure_storage::{set, restore};
 
-set("token", "secret")?;
-let _ = restore("token")?;
-# Ok::<(), wasm_bindgen::JsValue>(())
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+set("token", "secret").await?;
+let _ = restore("token").await?;
+# Ok(())
+# }
 ```
 
 

--- a/src/api/device_storage.rs
+++ b/src/api/device_storage.rs
@@ -1,5 +1,6 @@
-use js_sys::{Function, Reflect};
+use js_sys::{Function, Promise, Reflect};
 use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 use web_sys::window;
 
 /// Stores a value under the given key in Telegram's device storage.
@@ -11,14 +12,15 @@ use web_sys::window;
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::device_storage::set;
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("foo", "bar")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("foo", "bar").await?;
 /// # Ok(()) }
 /// ```
-pub fn set(key: &str, value: &str) -> Result<(), JsValue> {
+pub async fn set(key: &str, value: &str) -> Result<(), JsValue> {
     let storage = device_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("set"))?.dyn_into::<Function>()?;
-    func.call2(&storage, &JsValue::from_str(key), &JsValue::from_str(value))?;
+    let promise = func.call2(&storage, &JsValue::from_str(key), &JsValue::from_str(value))?;
+    JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(())
 }
 
@@ -31,16 +33,17 @@ pub fn set(key: &str, value: &str) -> Result<(), JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::device_storage::{get, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("foo", "bar")?;
-/// let value = get("foo")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("foo", "bar").await?;
+/// let value = get("foo").await?;
 /// assert_eq!(value.as_deref(), Some("bar"));
 /// # Ok(()) }
 /// ```
-pub fn get(key: &str) -> Result<Option<String>, JsValue> {
+pub async fn get(key: &str) -> Result<Option<String>, JsValue> {
     let storage = device_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("get"))?.dyn_into::<Function>()?;
-    let value = func.call1(&storage, &JsValue::from_str(key))?;
+    let promise = func.call1(&storage, &JsValue::from_str(key))?;
+    let value = JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(value.as_string())
 }
 
@@ -53,15 +56,16 @@ pub fn get(key: &str) -> Result<Option<String>, JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::device_storage::{remove, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("foo", "bar")?;
-/// remove("foo")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("foo", "bar").await?;
+/// remove("foo").await?;
 /// # Ok(()) }
 /// ```
-pub fn remove(key: &str) -> Result<(), JsValue> {
+pub async fn remove(key: &str) -> Result<(), JsValue> {
     let storage = device_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("remove"))?.dyn_into::<Function>()?;
-    func.call1(&storage, &JsValue::from_str(key))?;
+    let promise = func.call1(&storage, &JsValue::from_str(key))?;
+    JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(())
 }
 
@@ -74,15 +78,16 @@ pub fn remove(key: &str) -> Result<(), JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::device_storage::{clear, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("foo", "bar")?;
-/// clear()?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("foo", "bar").await?;
+/// clear().await?;
 /// # Ok(()) }
 /// ```
-pub fn clear() -> Result<(), JsValue> {
+pub async fn clear() -> Result<(), JsValue> {
     let storage = device_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("clear"))?.dyn_into::<Function>()?;
-    func.call0(&storage)?;
+    let promise = func.call0(&storage)?;
+    JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(())
 }
 
@@ -118,71 +123,71 @@ mod tests {
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn set_calls_js() {
+    async fn set_calls_js() {
         let storage = setup_device_storage();
         let func = Function::new_with_args("k,v", "this[k] = v;");
         let _ = Reflect::set(&storage, &"set".into(), &func);
-        assert!(set("a", "b").is_ok());
+        assert!(set("a", "b").await.is_ok());
         let val = Reflect::get(&storage, &"a".into()).unwrap();
         assert_eq!(val.as_string().as_deref(), Some("b"));
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn set_err() {
-        assert!(set("a", "b").is_err());
+    async fn set_err() {
+        assert!(set("a", "b").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn get_calls_js() {
+    async fn get_calls_js() {
         let storage = setup_device_storage();
         let func = Function::new_with_args("k", "return this[k];");
         let _ = Reflect::set(&storage, &"get".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        let value = get("a").unwrap();
+        let value = get("a").await.unwrap();
         assert_eq!(value.as_deref(), Some("b"));
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn get_err() {
-        assert!(get("a").is_err());
+    async fn get_err() {
+        assert!(get("a").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn remove_calls_js() {
+    async fn remove_calls_js() {
         let storage = setup_device_storage();
         let func = Function::new_with_args("k", "delete this[k];");
         let _ = Reflect::set(&storage, &"remove".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        assert!(remove("a").is_ok());
+        assert!(remove("a").await.is_ok());
         let has = Reflect::has(&storage, &"a".into()).unwrap();
         assert!(!has);
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn remove_err() {
-        assert!(remove("a").is_err());
+    async fn remove_err() {
+        assert!(remove("a").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn clear_calls_js() {
+    async fn clear_calls_js() {
         let storage = setup_device_storage();
         let func = Function::new_no_args("Object.keys(this).forEach(k => delete this[k]);");
         let _ = Reflect::set(&storage, &"clear".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        assert!(clear().is_ok());
+        assert!(clear().await.is_ok());
         let has = Reflect::has(&storage, &"a".into()).unwrap();
         assert!(!has);
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn clear_err() {
-        assert!(clear().is_err());
+    async fn clear_err() {
+        assert!(clear().await.is_err());
     }
 }

--- a/src/api/secure_storage.rs
+++ b/src/api/secure_storage.rs
@@ -1,5 +1,6 @@
-use js_sys::{Function, Reflect};
+use js_sys::{Function, Promise, Reflect};
 use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 use web_sys::window;
 
 /// Stores a value under the given key in Telegram's secure storage.
@@ -14,14 +15,15 @@ use web_sys::window;
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::secure_storage::set;
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("token", "123")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("token", "123").await?;
 /// # Ok(()) }
 /// ```
-pub fn set(key: &str, value: &str) -> Result<(), JsValue> {
+pub async fn set(key: &str, value: &str) -> Result<(), JsValue> {
     let storage = secure_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("set"))?.dyn_into::<Function>()?;
-    func.call2(&storage, &JsValue::from_str(key), &JsValue::from_str(value))?;
+    let promise = func.call2(&storage, &JsValue::from_str(key), &JsValue::from_str(value))?;
+    JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(())
 }
 
@@ -34,16 +36,17 @@ pub fn set(key: &str, value: &str) -> Result<(), JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::secure_storage::{get, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("token", "123")?;
-/// let value = get("token")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("token", "123").await?;
+/// let value = get("token").await?;
 /// assert_eq!(value.as_deref(), Some("123"));
 /// # Ok(()) }
 /// ```
-pub fn get(key: &str) -> Result<Option<String>, JsValue> {
+pub async fn get(key: &str) -> Result<Option<String>, JsValue> {
     let storage = secure_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("get"))?.dyn_into::<Function>()?;
-    let value = func.call1(&storage, &JsValue::from_str(key))?;
+    let promise = func.call1(&storage, &JsValue::from_str(key))?;
+    let value = JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(value.as_string())
 }
 
@@ -56,16 +59,17 @@ pub fn get(key: &str) -> Result<Option<String>, JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::secure_storage::{remove, restore, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("token", "123")?;
-/// remove("token")?;
-/// let _ = restore("token")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("token", "123").await?;
+/// remove("token").await?;
+/// let _ = restore("token").await?;
 /// # Ok(()) }
 /// ```
-pub fn restore(key: &str) -> Result<Option<String>, JsValue> {
+pub async fn restore(key: &str) -> Result<Option<String>, JsValue> {
     let storage = secure_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("restore"))?.dyn_into::<Function>()?;
-    let value = func.call1(&storage, &JsValue::from_str(key))?;
+    let promise = func.call1(&storage, &JsValue::from_str(key))?;
+    let value = JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(value.as_string())
 }
 
@@ -78,15 +82,16 @@ pub fn restore(key: &str) -> Result<Option<String>, JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::secure_storage::{remove, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("token", "123")?;
-/// remove("token")?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("token", "123").await?;
+/// remove("token").await?;
 /// # Ok(()) }
 /// ```
-pub fn remove(key: &str) -> Result<(), JsValue> {
+pub async fn remove(key: &str) -> Result<(), JsValue> {
     let storage = secure_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("remove"))?.dyn_into::<Function>()?;
-    func.call1(&storage, &JsValue::from_str(key))?;
+    let promise = func.call1(&storage, &JsValue::from_str(key))?;
+    JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(())
 }
 
@@ -99,15 +104,16 @@ pub fn remove(key: &str) -> Result<(), JsValue> {
 /// # Examples
 /// ```
 /// use telegram_webapp_sdk::api::secure_storage::{clear, set};
-/// # fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// set("token", "123")?;
-/// clear()?;
+/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+/// set("token", "123").await?;
+/// clear().await?;
 /// # Ok(()) }
 /// ```
-pub fn clear() -> Result<(), JsValue> {
+pub async fn clear() -> Result<(), JsValue> {
     let storage = secure_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("clear"))?.dyn_into::<Function>()?;
-    func.call0(&storage)?;
+    let promise = func.call0(&storage)?;
+    JsFuture::from(promise.dyn_into::<Promise>()?).await?;
     Ok(())
 }
 
@@ -143,88 +149,88 @@ mod tests {
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn set_calls_js() {
+    async fn set_calls_js() {
         let storage = setup_secure_storage();
         let func = Function::new_with_args("k,v", "this[k] = v;");
         let _ = Reflect::set(&storage, &"set".into(), &func);
-        assert!(set("a", "b").is_ok());
+        assert!(set("a", "b").await.is_ok());
         let val = Reflect::get(&storage, &"a".into()).unwrap();
         assert_eq!(val.as_string().as_deref(), Some("b"));
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn set_err() {
-        assert!(set("a", "b").is_err());
+    async fn set_err() {
+        assert!(set("a", "b").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn get_calls_js() {
+    async fn get_calls_js() {
         let storage = setup_secure_storage();
         let func = Function::new_with_args("k", "return this[k];");
         let _ = Reflect::set(&storage, &"get".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        let value = get("a").unwrap();
+        let value = get("a").await.unwrap();
         assert_eq!(value.as_deref(), Some("b"));
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn get_err() {
-        assert!(get("a").is_err());
+    async fn get_err() {
+        assert!(get("a").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn restore_calls_js() {
+    async fn restore_calls_js() {
         let storage = setup_secure_storage();
         let func = Function::new_with_args("k", "return this[k];");
         let _ = Reflect::set(&storage, &"restore".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        let value = restore("a").unwrap();
+        let value = restore("a").await.unwrap();
         assert_eq!(value.as_deref(), Some("b"));
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn restore_err() {
-        assert!(restore("a").is_err());
+    async fn restore_err() {
+        assert!(restore("a").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn remove_calls_js() {
+    async fn remove_calls_js() {
         let storage = setup_secure_storage();
         let func = Function::new_with_args("k", "delete this[k];");
         let _ = Reflect::set(&storage, &"remove".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        assert!(remove("a").is_ok());
+        assert!(remove("a").await.is_ok());
         let has = Reflect::has(&storage, &"a".into()).unwrap();
         assert!(!has);
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn remove_err() {
-        assert!(remove("a").is_err());
+    async fn remove_err() {
+        assert!(remove("a").await.is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn clear_calls_js() {
+    async fn clear_calls_js() {
         let storage = setup_secure_storage();
         let func = Function::new_no_args("Object.keys(this).forEach(k => delete this[k]);");
         let _ = Reflect::set(&storage, &"clear".into(), &func);
         let _ = Reflect::set(&storage, &"a".into(), &JsValue::from_str("b"));
-        assert!(clear().is_ok());
+        assert!(clear().await.is_ok());
         let has = Reflect::has(&storage, &"a".into()).unwrap();
         assert!(!has);
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code)]
-    fn clear_err() {
-        assert!(clear().is_err());
+    async fn clear_err() {
+        assert!(clear().await.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- await deviceStorage and secureStorage promises so results and errors propagate

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2ac05a054832b96027833435054d9