### PR TITLE
Add biometric API module

### DIFF
--- a/src/api/biometric.rs
+++ b/src/api/biometric.rs
@@ -31,12 +31,20 @@ pub fn init() -> Result<(), JsValue> {
 /// ```no_run
 /// use telegram_webapp_sdk::api::biometric::request_access;
 ///
-/// let _ = request_access();
+/// let _ = request_access("auth_key", None);
 /// ```
-pub fn request_access() -> Result<(), JsValue> {
+pub fn request_access(auth_key: &str, params: Option<&JsValue>) -> Result<(), JsValue> {
     let biom = biometric_object()?;
-    let func = Reflect::get(&biom, &JsValue::from_str("requestAccess"))?.dyn_into::<Function>()?;
-    func.call0(&biom)?;
+    let func = Reflect::get(&biom, &JsValue::from_str("requestAccess"))?
+        .dyn_into::<Function>()?;
+    match params {
+        Some(p) => {
+            func.call2(&biom, &JsValue::from_str(auth_key), p)?;
+        }
+        None => {
+            func.call1(&biom, &JsValue::from_str(auth_key))?;
+        }
+    }
     Ok(())
 }
 
@@ -50,12 +58,39 @@ pub fn request_access() -> Result<(), JsValue> {
 /// ```no_run
 /// use telegram_webapp_sdk::api::biometric::authenticate;
 ///
-/// let _ = authenticate();
+/// let _ = authenticate("auth_key", None, None);
 /// ```
-pub fn authenticate() -> Result<(), JsValue> {
+pub fn authenticate(
+    auth_key: &str,
+    reason: Option<&str>,
+    options: Option<&JsValue>,
+) -> Result<(), JsValue> {
     let biom = biometric_object()?;
-    let func = Reflect::get(&biom, &JsValue::from_str("authenticate"))?.dyn_into::<Function>()?;
-    func.call0(&biom)?;
+    let func = Reflect::get(&biom, &JsValue::from_str("authenticate"))?
+        .dyn_into::<Function>()?;
+    match (reason, options) {
+        (Some(r), Some(o)) => {
+            func.call3(
+                &biom,
+                &JsValue::from_str(auth_key),
+                &JsValue::from_str(r),
+                o,
+            )?;
+        }
+        (Some(r), None) => {
+            func.call2(
+                &biom,
+                &JsValue::from_str(auth_key),
+                &JsValue::from_str(r),
+            )?;
+        }
+        (None, Some(o)) => {
+            func.call2(&biom, &JsValue::from_str(auth_key), o)?;
+        }
+        (None, None) => {
+            func.call1(&biom, &JsValue::from_str(auth_key))?;
+        }
+    }
     Ok(())
 }
 
@@ -151,40 +186,54 @@ mod tests {
     #[allow(dead_code, clippy::unused_unit)]
     fn request_access_ok() {
         let biom = setup_biometric();
-        let func = Function::new_no_args("this.called = true;");
+        let func = Function::new_with_args("key", "this.key = key;");
         let _ = Reflect::set(&biom, &"requestAccess".into(), &func);
-        assert!(request_access().is_ok());
-        assert!(Reflect::get(&biom, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(request_access("abc", None).is_ok());
+        assert_eq!(
+            Reflect::get(&biom, &"key".into())
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            "abc"
+        );
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
     fn request_access_err() {
         let _ = setup_biometric();
-        assert!(request_access().is_err());
+        assert!(request_access("abc", None).is_err());
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
     fn authenticate_ok() {
         let biom = setup_biometric();
-        let func = Function::new_no_args("this.called = true;");
+        let func =
+            Function::new_with_args("key, reason", "this.key = key; this.reason = reason;");
         let _ = Reflect::set(&biom, &"authenticate".into(), &func);
-        assert!(authenticate().is_ok());
-        assert!(Reflect::get(&biom, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(authenticate("abc", Some("why"), None).is_ok());
+        assert_eq!(
+            Reflect::get(&biom, &"key".into())
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            "abc"
+        );
+        assert_eq!(
+            Reflect::get(&biom, &"reason".into())
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            "why"
+        );
     }
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
     fn authenticate_err() {
         let _ = setup_biometric();
-        assert!(authenticate().is_err());
+        assert!(authenticate("abc", None, None).is_err());
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- forward auth key and params to `request_access`
- support auth key, optional reason and options for `authenticate`

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2ac629f60832bacdd783dea281784