### PR TITLE
docs: avoid unwrap in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,17 @@ Request access to sensitive user data or open the contact interface:
 use telegram_webapp_sdk::api::user::{request_contact, request_phone_number, open_contact};
 use telegram_webapp_sdk::webapp::TelegramWebApp;
 
-let _ = request_contact();
-let _ = request_phone_number();
-let _ = open_contact();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+request_contact()?;
+request_phone_number()?;
+open_contact()?;
 
-let app = TelegramWebApp::instance().unwrap();
-let _ = app.request_write_access(|granted| {
+let app = TelegramWebApp::try_instance()?;
+app.request_write_access(|granted| {
     let _ = granted;
-});
+})?;
+# Ok(())
+# }
 ```
 
 These calls require the user's explicit permission before any information is shared.
@@ -88,9 +91,11 @@ Hide the native keyboard when it's no longer required:
 
 ```rust,no_run
 use telegram_webapp_sdk::webapp::TelegramWebApp;
-
-let app = TelegramWebApp::instance().unwrap();
-app.hide_keyboard().unwrap();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+app.hide_keyboard()?;
+# Ok(())
+# }
 ```
 
 ## Closing confirmation
@@ -99,11 +104,13 @@ Prompt users before the Mini App closes:
 
 ```rust,no_run
 use telegram_webapp_sdk::webapp::TelegramWebApp;
-
-let app = TelegramWebApp::instance().unwrap();
-app.enable_closing_confirmation().unwrap();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+app.enable_closing_confirmation()?;
 // later
-app.disable_closing_confirmation().unwrap();
+app.disable_closing_confirmation()?;
+# Ok(())
+# }
 ```
 ## Sharing
 
@@ -113,7 +120,8 @@ Share links, prepared messages, or stories and join voice chats:
 use js_sys::Object;
 use telegram_webapp_sdk::webapp::TelegramWebApp;
 
-let app = TelegramWebApp::instance().unwrap();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
 app.share_url("https://example.com", Some("Check this out"))?;
 app.join_voice_chat("chat", None)?;
 app.share_message("msg-id", |sent| {
@@ -121,7 +129,10 @@ app.share_message("msg-id", |sent| {
 })?;
 let params = Object::new();
 app.share_to_story("https://example.com/image.png", Some(&params.into()))?;
-# Ok::<(), wasm_bindgen::JsValue>(())
+# Ok(())
+# }
+```
+
 ## Settings button
 
 Control the Telegram client's settings button and handle user clicks:
@@ -161,12 +172,14 @@ Prompt users to add the app to their home screen and check the current status:
 
 ```rust,no_run
 use telegram_webapp_sdk::webapp::TelegramWebApp;
-
-let app = TelegramWebApp::instance().unwrap();
-let _shown = app.add_to_home_screen().unwrap();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+let _shown = app.add_to_home_screen()?;
 app.check_home_screen_status(|status| {
     let _ = status;
-}).unwrap();
+})?;
+# Ok(())
+# }
 ```
 
 ## Event callbacks
@@ -175,11 +188,14 @@ Callback registration methods return an `EventHandle` for later deregistration.
 
 ```rust,no_run
 use telegram_webapp_sdk::webapp::TelegramWebApp;
-let app = TelegramWebApp::instance().unwrap();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
 let handle = app.on_event("my_event", |value| {
     let _ = value;
-}).unwrap();
-app.off_event(handle).unwrap();
+})?;
+app.off_event(handle)?;
+# Ok(())
+# }
 ```
 
 ## Appearance
@@ -191,20 +207,23 @@ Control the Mini App display and screen orientation:
 
 ```rust,no_run
 use telegram_webapp_sdk::webapp::TelegramWebApp;
-let app = TelegramWebApp::instance().unwrap();
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
 app.set_header_color("#000000")?;
 app.set_background_color("#ffffff")?;
 app.set_bottom_bar_color("#cccccc")?;
-let theme_handle = app.on_theme_changed(|| {}).unwrap();
-let safe_handle = app.on_safe_area_changed(|| {}).unwrap();
-let content_handle = app.on_content_safe_area_changed(|| {}).unwrap();
+let theme_handle = app.on_theme_changed(|| {})?;
+let safe_handle = app.on_safe_area_changed(|| {})?;
+let content_handle = app.on_content_safe_area_changed(|| {})?;
 // later: app.off_event(theme_handle)?; etc.
-# Ok::<(), wasm_bindgen::JsValue>(())
-app.request_fullscreen().unwrap();
-app.lock_orientation("portrait").unwrap();
+
+app.request_fullscreen()?;
+app.lock_orientation("portrait")?;
 // later...
-app.unlock_orientation().unwrap();
-app.exit_fullscreen().unwrap();
+app.unlock_orientation()?;
+app.exit_fullscreen()?;
+# Ok(())
+# }
 ```
 
 ## Haptic feedback

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -1,6 +1,6 @@
 use js_sys::{Function, Object, Reflect};
 use serde_wasm_bindgen::to_value;
-use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::window;
 
 use crate::{core::types::download_file_params::DownloadFileParams, logger};
@@ -76,6 +76,21 @@ impl TelegramWebApp {
         let tg = Reflect::get(&win, &"Telegram".into()).ok()?;
         let webapp = Reflect::get(&tg, &"WebApp".into()).ok()?;
         webapp.dyn_into::<Object>().ok().map(|inner| Self {
+            inner
+        })
+    }
+
+    /// Try to get instance of `Telegram.WebApp`.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the `Telegram.WebApp` object is missing or
+    /// malformed.
+    pub fn try_instance() -> Result<Self, JsValue> {
+        let win = window().ok_or_else(|| JsValue::from_str("window not available"))?;
+        let tg = Reflect::get(&win, &"Telegram".into())?;
+        let webapp = Reflect::get(&tg, &"WebApp".into())?;
+        let inner = webapp.dyn_into::<Object>()?;
+        Ok(Self {
             inner
         })
     }
@@ -743,7 +758,7 @@ impl TelegramWebApp {
     /// })
     /// .unwrap();
     /// ```
-    /// 
+    ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn read_text_from_clipboard<F>(&self, callback: F) -> Result<(), JsValue>

--- a/tests/closing_confirmation.rs
+++ b/tests/closing_confirmation.rs
@@ -2,57 +2,59 @@ use std::{cell::Cell, rc::Rc};
 
 use js_sys::{Object, Reflect};
 use telegram_webapp_sdk::webapp::TelegramWebApp;
-use wasm_bindgen::{JsCast, prelude::Closure};
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_sys::window;
 
-fn setup_webapp() -> Object {
-    let win = window().unwrap();
+fn setup_webapp() -> Result<Object, JsValue> {
+    let win = window().ok_or_else(|| JsValue::from_str("no window"))?;
     let telegram = Object::new();
     let webapp = Object::new();
-    let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
-    let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
-    webapp
+    Reflect::set(&win, &"Telegram".into(), &telegram)?;
+    Reflect::set(&telegram, &"WebApp".into(), &webapp)?;
+    Ok(webapp)
 }
 
 #[wasm_bindgen_test]
-fn enable_closing_confirmation_calls_js() {
-    let webapp = setup_webapp();
+fn enable_closing_confirmation_calls_js() -> Result<(), JsValue> {
+    let webapp = setup_webapp()?;
     let called = Rc::new(Cell::new(false));
     let called_clone = Rc::clone(&called);
 
     let cb = Closure::<dyn FnMut()>::new(move || {
         called_clone.set(true);
     });
-    let _ = Reflect::set(
+    Reflect::set(
         &webapp,
         &"enableClosingConfirmation".into(),
         cb.as_ref().unchecked_ref()
-    );
+    )?;
     cb.forget();
 
-    let app = TelegramWebApp::instance().unwrap();
-    app.enable_closing_confirmation().unwrap();
+    let app = TelegramWebApp::try_instance()?;
+    app.enable_closing_confirmation()?;
     assert!(called.get());
+    Ok(())
 }
 
 #[wasm_bindgen_test]
-fn disable_closing_confirmation_calls_js() {
-    let webapp = setup_webapp();
+fn disable_closing_confirmation_calls_js() -> Result<(), JsValue> {
+    let webapp = setup_webapp()?;
     let called = Rc::new(Cell::new(false));
     let called_clone = Rc::clone(&called);
 
     let cb = Closure::<dyn FnMut()>::new(move || {
         called_clone.set(true);
     });
-    let _ = Reflect::set(
+    Reflect::set(
         &webapp,
         &"disableClosingConfirmation".into(),
         cb.as_ref().unchecked_ref()
-    );
+    )?;
     cb.forget();
 
-    let app = TelegramWebApp::instance().unwrap();
-    app.disable_closing_confirmation().unwrap();
+    let app = TelegramWebApp::try_instance()?;
+    app.disable_closing_confirmation()?;
     assert!(called.get());
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add `try_instance` helper returning `Result` for `TelegramWebApp`
- rewrite README and closing confirmation tests to propagate errors instead of `unwrap`

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2b7be3338832b9e701a2f74b27949