### PR TITLE
Add closing confirmation status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ use telegram_webapp_sdk::webapp::TelegramWebApp;
 # fn run() -> Result<(), wasm_bindgen::JsValue> {
 let app = TelegramWebApp::try_instance()?;
 app.enable_closing_confirmation()?;
+assert!(app.is_closing_confirmation_enabled());
 // later
 app.disable_closing_confirmation()?;
 # Ok(())

--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -39,6 +39,7 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] checkHomeScreenStatus ([e709edb](https://github.com/RAprogramm/telegram-webapp-sdk/commit/e709edb))
 - [x] enableClosingConfirmation ([8fe4dec](https://github.com/RAprogramm/telegram-webapp-sdk/commit/8fe4dec))
 - [x] disableClosingConfirmation ([8fe4dec](https://github.com/RAprogramm/telegram-webapp-sdk/commit/8fe4dec))
+- [x] isClosingConfirmationEnabled (unreleased)
 - [x] requestFullscreen ([4364008](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4364008))
 - [x] exitFullscreen ([4364008](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4364008))
 - [x] lockOrientation ([4364008](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4364008))

--- a/src/api/biometric.rs
+++ b/src/api/biometric.rs
@@ -1,5 +1,5 @@
 use js_sys::{Function, Reflect};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use web_sys::window;
 
 /// Calls `Telegram.WebApp.BiometricManager.init()`.
@@ -291,10 +291,12 @@ mod tests {
         let func = Function::new_no_args("this.called = true;");
         let _ = Reflect::set(&biom, &"init".into(), &func);
         assert!(init().is_ok());
-        assert!(Reflect::get(&biom, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(
+            Reflect::get(&biom, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[wasm_bindgen_test]
@@ -311,10 +313,12 @@ mod tests {
         let func = Function::new_with_args("key", "this.called = true; this.key = key;");
         let _ = Reflect::set(&biom, &"requestAccess".into(), &func);
         assert!(request_access("abc", None, None).is_ok());
-        assert!(Reflect::get(&biom, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(
+            Reflect::get(&biom, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
         assert_eq!(
             Reflect::get(&biom, &"key".into())
                 .unwrap()
@@ -338,10 +342,12 @@ mod tests {
         let func = Function::new_with_args("key", "this.called = true; this.key = key;");
         let _ = Reflect::set(&biom, &"authenticate".into(), &func);
         assert!(authenticate("abc", None, None).is_ok());
-        assert!(Reflect::get(&biom, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(
+            Reflect::get(&biom, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
         assert_eq!(
             Reflect::get(&biom, &"key".into())
                 .unwrap()
@@ -395,10 +401,12 @@ mod tests {
         let func = Function::new_no_args("this.called = true;");
         let _ = Reflect::set(&biom, &"openSettings".into(), &func);
         assert!(open_settings().is_ok());
-        assert!(Reflect::get(&biom, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(
+            Reflect::get(&biom, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[wasm_bindgen_test]

--- a/src/api/settings_button.rs
+++ b/src/api/settings_button.rs
@@ -1,5 +1,5 @@
 use js_sys::{Function, Reflect};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use web_sys::window;
 
 /// Show the Telegram Settings Button.
@@ -125,10 +125,12 @@ mod tests {
         let func = Function::new_no_args("this.called = true;");
         let _ = Reflect::set(&button, &"show".into(), &func);
         assert!(show().is_ok());
-        assert!(Reflect::get(&button, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(
+            Reflect::get(&button, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[wasm_bindgen_test]
@@ -138,10 +140,12 @@ mod tests {
         let func = Function::new_no_args("this.called = true;");
         let _ = Reflect::set(&button, &"hide".into(), &func);
         assert!(hide().is_ok());
-        assert!(Reflect::get(&button, &"called".into())
-            .unwrap()
-            .as_bool()
-            .unwrap());
+        assert!(
+            Reflect::get(&button, &"called".into())
+                .unwrap()
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[wasm_bindgen_test]

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -149,6 +149,21 @@ impl TelegramWebApp {
         self.call0("disableClosingConfirmation")
     }
 
+    /// Returns whether closing confirmation is currently enabled.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// let _ = app.is_closing_confirmation_enabled();
+    /// ```
+    pub fn is_closing_confirmation_enabled(&self) -> bool {
+        Reflect::get(&self.inner, &"isClosingConfirmationEnabled".into())
+            .ok()
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
     /// Call `WebApp.requestFullscreen()`.
     ///
     /// # Examples

--- a/tests/closing_confirmation.rs
+++ b/tests/closing_confirmation.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use std::{cell::Cell, rc::Rc};
 
 use js_sys::{Object, Reflect};
@@ -56,5 +58,26 @@ fn disable_closing_confirmation_calls_js() -> Result<(), JsValue> {
     let app = TelegramWebApp::try_instance()?;
     app.disable_closing_confirmation()?;
     assert!(called.get());
+    Ok(())
+}
+
+#[wasm_bindgen_test]
+fn is_closing_confirmation_enabled_reflects_js() -> Result<(), JsValue> {
+    let webapp = setup_webapp()?;
+    Reflect::set(
+        &webapp,
+        &"isClosingConfirmationEnabled".into(),
+        &JsValue::TRUE
+    )?;
+
+    let app = TelegramWebApp::try_instance()?;
+    assert!(app.is_closing_confirmation_enabled());
+
+    Reflect::set(
+        &webapp,
+        &"isClosingConfirmationEnabled".into(),
+        &JsValue::FALSE
+    )?;
+    assert!(!app.is_closing_confirmation_enabled());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- expose `is_closing_confirmation_enabled` to query Web App closing confirmation state
- document and test closing confirmation status
- track coverage for `isClosingConfirmationEnabled`

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo test --target wasm32-unknown-unknown --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68c373417a00832b82882123470b4963