### PR TITLE
feat: add init data validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,14 +309,19 @@ Callbacks for sensor lifecycle events are available through `on_started`,
 gyroscope, and device orientation sensors.
 ## Init data validation
 
-Validate the integrity of the `Telegram.WebApp.initData` payload on the server:
+Validate the integrity of the `Telegram.WebApp.initData` payload on the server.
+The `validate_init_data` module is re-exported at the crate root and can be
+used directly or through the `TelegramWebApp::validate_init_data` helper:
 
 ```rust
-use telegram_webapp_sdk::utils::validate_init_data::{verify_hmac_sha256, verify_ed25519};
+use telegram_webapp_sdk::{
+    validate_init_data::ValidationKey,
+    TelegramWebApp
+};
 
 let bot_token = "123456:ABC";
 let query = "user=alice&auth_date=1&hash=48f4c0e9d3dd46a5734bf2c5d4df9f4ec52a3cd612f6482a7d2c68e84e702ee2";
-verify_hmac_sha256(query, bot_token)?;
+TelegramWebApp::validate_init_data(query, ValidationKey::BotToken(bot_token))?;
 
 // For Ed25519-signed data
 # use ed25519_dalek::{Signer, SigningKey};
@@ -324,7 +329,10 @@ verify_hmac_sha256(query, bot_token)?;
 # let pk = sk.verifying_key();
 # let sig = sk.sign(b"a=1\nb=2");
 # let init_data = format!("a=1&b=2&signature={}", base64::encode(sig.to_bytes()));
-verify_ed25519(&init_data, pk.as_bytes())?;
+TelegramWebApp::validate_init_data(
+    &init_data,
+    ValidationKey::Ed25519PublicKey(pk.as_bytes())
+)?;
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```

--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -146,10 +146,36 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 
 The following features are not yet covered by the SDK:
 
-- [ ] Init data validation
+- [x] Init data validation (unreleased)
 - [x] Theme and safe area change events ([58a73cb](https://github.com/RAprogramm/telegram-webapp-sdk/commit/58a73cb))
 - [ ] Viewport management
 - [x] Clipboard access ([fd1c84e](https://github.com/RAprogramm/telegram-webapp-sdk/commit/fd1c84e))
 - [x] Location access ([10ca55c](https://github.com/RAprogramm/telegram-webapp-sdk/commit/10ca55c))
 - [ ] Invoice payments
 - [ ] Background events
+
+### Init data validation
+
+```rust
+use telegram_webapp_sdk::{
+    validate_init_data::ValidationKey,
+    TelegramWebApp
+};
+
+let bot_token = "123456:ABC";
+let query = "user=alice&auth_date=1&hash=48f4c0e9d3dd46a5734bf2c5d4df9f4ec52a3cd612f6482a7d2c68e84e702ee2";
+TelegramWebApp::validate_init_data(query, ValidationKey::BotToken(bot_token))?;
+
+// For Ed25519-signed data
+# use ed25519_dalek::{Signer, SigningKey};
+# let sk = SigningKey::from_bytes(&[1u8;32]);
+# let pk = sk.verifying_key();
+# let sig = sk.sign(b"a=1\nb=2");
+# let init_data = format!("a=1&b=2&signature={}", base64::encode(sig.to_bytes()));
+TelegramWebApp::validate_init_data(
+    &init_data,
+    ValidationKey::Ed25519PublicKey(pk.as_bytes())
+)?;
+
+# Ok::<(), telegram_webapp_sdk::validate_init_data::ValidationError>(())
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod logger;
 pub mod mock;
 pub mod utils;
 pub mod webapp;
+pub use utils::validate_init_data;
 pub use webapp::TelegramWebApp;
 
 #[cfg(feature = "yew")]

--- a/src/utils/validate_init_data.rs
+++ b/src/utils/validate_init_data.rs
@@ -24,6 +24,15 @@ pub enum ValidationError {
     InvalidPublicKey
 }
 
+/// Key material used to validate Telegram init data.
+#[derive(Clone, Copy, Debug)]
+pub enum ValidationKey<'a> {
+    /// Validate using a bot token and HMAC-SHA256.
+    BotToken(&'a str),
+    /// Validate using an Ed25519 public key.
+    Ed25519PublicKey(&'a [u8; 32])
+}
+
 /// Validates the `hash` parameter of the init data using HMAC-SHA256.
 ///
 /// The `init_data` string must be the exact value of
@@ -37,7 +46,7 @@ pub enum ValidationError {
 /// # Examples
 /// ```
 /// use hmac_sha256::{HMAC, Hash};
-/// use telegram_webapp_sdk::utils::validate_init_data::verify_hmac_sha256;
+/// use telegram_webapp_sdk::validate_init_data::verify_hmac_sha256;
 /// let token = "123456:ABC";
 /// let check_string = "auth_date=1\nuser=alice";
 /// let secret = Hash::hash(format!("WebAppData{token}").as_bytes());
@@ -73,7 +82,7 @@ pub fn verify_hmac_sha256(init_data: &str, bot_token: &str) -> Result<(), Valida
 /// # Examples
 /// ```
 /// use ed25519_dalek::{Signer, SigningKey};
-/// use telegram_webapp_sdk::utils::validate_init_data::verify_ed25519;
+/// use telegram_webapp_sdk::validate_init_data::verify_ed25519;
 ///
 /// // generate test key
 /// let sk = SigningKey::from_bytes(&[1u8; 32]);

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -3,7 +3,11 @@ use serde_wasm_bindgen::to_value;
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::window;
 
-use crate::{core::types::download_file_params::DownloadFileParams, logger};
+use crate::{
+    core::types::download_file_params::DownloadFileParams,
+    logger,
+    validate_init_data::{self, ValidationKey}
+};
 
 /// Handle returned when registering callbacks.
 pub struct EventHandle<T: ?Sized> {
@@ -93,6 +97,36 @@ impl TelegramWebApp {
         Ok(Self {
             inner
         })
+    }
+
+    /// Validate an `initData` payload using either HMAC-SHA256 or Ed25519.
+    ///
+    /// Pass [`ValidationKey::BotToken`] to verify the `hash` parameter using
+    /// the bot token. Use [`ValidationKey::Ed25519PublicKey`] to verify the
+    /// `signature` parameter with an Ed25519 public key.
+    ///
+    /// # Errors
+    /// Returns [`validate_init_data::ValidationError`] if validation fails.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use telegram_webapp_sdk::{TelegramWebApp, validate_init_data::ValidationKey};
+    /// let bot_token = "123456:ABC";
+    /// let query = "a=1&b=2&hash=9e5e8d7c0b1f9f3a";
+    /// TelegramWebApp::validate_init_data(query, ValidationKey::BotToken(bot_token)).unwrap();
+    /// ```
+    pub fn validate_init_data(
+        init_data: &str,
+        key: ValidationKey
+    ) -> Result<(), validate_init_data::ValidationError> {
+        match key {
+            ValidationKey::BotToken(token) => {
+                validate_init_data::verify_hmac_sha256(init_data, token)
+            }
+            ValidationKey::Ed25519PublicKey(pk) => {
+                validate_init_data::verify_ed25519(init_data, pk)
+            }
+        }
     }
 
     /// Call `WebApp.sendData(data)`.

--- a/tests/validate_init_data.rs
+++ b/tests/validate_init_data.rs
@@ -1,0 +1,74 @@
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use ed25519_dalek::{Signer, SigningKey};
+use hmac_sha256::{HMAC, Hash};
+use telegram_webapp_sdk::{
+    TelegramWebApp,
+    validate_init_data::{ValidationError, ValidationKey}
+};
+
+#[test]
+fn hmac_validates() {
+    let bot_token = "123456:ABC";
+    let secret_key = Hash::hash(format!("WebAppData{bot_token}").as_bytes());
+    let check_string = "a=1\nb=2";
+    let expected = HMAC::mac(check_string.as_bytes(), secret_key);
+    let hash = hex::encode(expected);
+    let query = format!("a=1&b=2&hash={hash}");
+    assert!(
+        TelegramWebApp::validate_init_data(&query, ValidationKey::BotToken(bot_token)).is_ok()
+    );
+}
+
+#[test]
+fn hmac_rejects_modified_data() {
+    let bot_token = "123456:ABC";
+    let secret_key = Hash::hash(format!("WebAppData{bot_token}").as_bytes());
+    let check_string = "a=1\nb=2";
+    let expected = HMAC::mac(check_string.as_bytes(), secret_key);
+    let hash = hex::encode(expected);
+    assert_eq!(
+        TelegramWebApp::validate_init_data(
+            &format!("a=1&b=3&hash={hash}"),
+            ValidationKey::BotToken(bot_token)
+        ),
+        Err(ValidationError::SignatureMismatch)
+    );
+}
+
+#[test]
+fn ed25519_validates() {
+    let sk = SigningKey::from_bytes(&[42u8; 32]);
+    let pk = sk.verifying_key();
+    let message = "a=1\nb=2";
+    let sig = sk.sign(message.as_bytes());
+    let init_data = format!(
+        "a=1&b=2&signature={}",
+        BASE64_STANDARD.encode(sig.to_bytes())
+    );
+    assert!(
+        TelegramWebApp::validate_init_data(
+            &init_data,
+            ValidationKey::Ed25519PublicKey(pk.as_bytes())
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn ed25519_rejects_bad_signature() {
+    let sk = SigningKey::from_bytes(&[42u8; 32]);
+    let pk = sk.verifying_key();
+    let message = "a=1\nb=2";
+    let sig = sk.sign(message.as_bytes());
+    let tampered = format!(
+        "a=1&b=3&signature={}",
+        BASE64_STANDARD.encode(sig.to_bytes())
+    );
+    assert_eq!(
+        TelegramWebApp::validate_init_data(
+            &tampered,
+            ValidationKey::Ed25519PublicKey(pk.as_bytes())
+        ),
+        Err(ValidationError::SignatureMismatch)
+    );
+}


### PR DESCRIPTION
## Summary
- re-export validate_init_data module at crate root
- add TelegramWebApp::validate_init_data helper with ValidationKey
- document and test HMAC and Ed25519 init data validation flows

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c3776b4374832ba0c3c0dab96591aa