### PR TITLE
chore(ci): use nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           components: clippy
           override: true
       - name: Install nightly rustfmt


### PR DESCRIPTION
## Summary
- use nightly toolchain in CI to support Rust 2024 edition

## Testing
- `cargo +nightly fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `wasm-pack test --headless --chrome` *(fails: Network unreachable (os error 101))*

------
https://chatgpt.com/codex/tasks/task_e_68c376c4f758832b9034dfa16c98bef6