### PR TITLE
docs: mark viewport management feature as complete

### DIFF
--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -163,7 +163,7 @@ The following features are not yet covered by the SDK:
 
 - [x] Init data validation (unreleased)
 - [x] Theme and safe area change events ([58a73cb](https://github.com/RAprogramm/telegram-webapp-sdk/commit/58a73cb))
-- [ ] Viewport management
+- [x] Viewport management
 - [x] Clipboard access ([fd1c84e](https://github.com/RAprogramm/telegram-webapp-sdk/commit/fd1c84e))
 - [x] Location access ([10ca55c](https://github.com/RAprogramm/telegram-webapp-sdk/commit/10ca55c))
 - [x] Invoice payments (unreleased)


### PR DESCRIPTION
## Summary
- mark viewport management as completed in API coverage

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c37a5bb694832ba94083c7bfe6788e