### PR TITLE
feat(demo): add burger king sample page

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -6,8 +6,9 @@ pub mod router;
 
 use components::dev_menu::setup_dev_menu;
 use pages::{
-    index::render_index_page, init_data::render_init_data_page,
-    launch_params::render_launch_params_page, theme_params::render_theme_params_page
+    burger_king::render_burger_king_page, index::render_index_page,
+    init_data::render_init_data_page, launch_params::render_launch_params_page,
+    theme_params::render_theme_params_page
 };
 use router::Router;
 use telegram_webapp_sdk::{
@@ -60,6 +61,7 @@ pub fn main() -> Result<(), JsValue> {
         .register("/init-data", render_init_data_page)
         .register("/launch-params", render_launch_params_page)
         .register("/theme-params", render_theme_params_page)
+        .register("/burger-king", render_burger_king_page)
         .start();
 
     Ok(())

--- a/demo/src/pages.rs
+++ b/demo/src/pages.rs
@@ -1,3 +1,4 @@
+pub mod burger_king;
 pub mod index;
 pub mod init_data;
 pub mod launch_params;

--- a/demo/src/pages/burger_king.rs
+++ b/demo/src/pages/burger_king.rs
@@ -1,0 +1,112 @@
+use telegram_webapp_sdk::{logger, webapp::TelegramWebApp};
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
+use web_sys::{Document, Element, HtmlElement, window};
+
+use crate::components::page_layout::PageLayout;
+
+/// Represents a single menu item in the Burger King demo.
+#[derive(Clone, Debug, PartialEq)]
+struct MenuItem {
+    id:          u32,
+    name:        &'static str,
+    price_cents: u32
+}
+
+impl MenuItem {
+    /// Build JSON payload describing the item.
+    fn payload(&self) -> String {
+        format!(
+            r#"{{"id":{},"name":"{}","price_cents":{}}}"#,
+            self.id, self.name, self.price_cents
+        )
+    }
+}
+
+/// Render Burger King menu page with order buttons.
+pub fn render_burger_king_page() {
+    let page = PageLayout::with_header("Burger King Demo", "Burger King Menu");
+
+    let items = [
+        MenuItem {
+            id:          1,
+            name:        "Whopper",
+            price_cents: 599
+        },
+        MenuItem {
+            id:          2,
+            name:        "Cheeseburger",
+            price_cents: 299
+        },
+        MenuItem {
+            id:          3,
+            name:        "Chicken Nuggets",
+            price_cents: 399
+        }
+    ];
+
+    for item in &items {
+        match render_item(item) {
+            Ok(el) => page.append(&el),
+            Err(err) => logger::error(&format!("render_item failed: {:?}", err))
+        }
+    }
+}
+
+fn render_item(item: &MenuItem) -> Result<Element, JsValue> {
+    let document = document()?;
+    let container = document.create_element("div")?;
+    container.set_class_name("menu-item");
+
+    let label = document.create_element("span")?;
+    label.set_inner_html(&format!(
+        "{} - ${:.2}",
+        item.name,
+        item.price_cents as f64 / 100.0
+    ));
+    container.append_child(&label)?;
+
+    let button = document.create_element("button")?;
+    button.set_inner_html("Order");
+    let button_el: HtmlElement = button.clone().dyn_into()?;
+
+    let item_clone = item.clone();
+    let click = Closure::<dyn FnMut()>::new(move || {
+        if let Some(app) = TelegramWebApp::instance() {
+            if let Err(err) = app.send_data(&item_clone.payload()) {
+                logger::error(&format!("send_data failed: {:?}", err));
+            }
+        } else {
+            logger::error("Telegram WebApp instance not found");
+        }
+    });
+    button_el.set_onclick(Some(click.as_ref().unchecked_ref()));
+    click.forget();
+
+    container.append_child(&button_el)?;
+    Ok(container)
+}
+
+fn document() -> Result<Document, JsValue> {
+    window()
+        .ok_or_else(|| JsValue::from_str("window not available"))?
+        .document()
+        .ok_or_else(|| JsValue::from_str("document not available"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_is_valid() {
+        let item = MenuItem {
+            id:          7,
+            name:        "Test",
+            price_cents: 1234
+        };
+        assert_eq!(
+            item.payload(),
+            "{\"id\":7,\"name\":\"Test\",\"price_cents\":1234}".to_string()
+        );
+    }
+}

--- a/demo/src/pages/index.rs
+++ b/demo/src/pages/index.rs
@@ -15,6 +15,11 @@ pub fn render_index_page() {
         Some("Connect your TON wallet"),
         "/ton-connect" // пока не реализовано, просто пример
     ));
+    page.append(&nav_link(
+        "Burger King Demo",
+        Some("Order burgers via Telegram"),
+        "/burger-king"
+    ));
 
     let app_data_header = section_header("Application Launch Data");
     page.append(&app_data_header);

--- a/demo/style.css
+++ b/demo/style.css
@@ -129,3 +129,23 @@ footer#dev-menu button:hover {
   border: 1px solid #555;
   border-radius: 50%;
 }
+.menu-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: white;
+  margin: 0.5rem 1rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.05);
+}
+
+.menu-item button {
+  padding: 0.5rem 1rem;
+  background-color: #e31e24;
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- add Burger King demo page sending orders through Telegram WebApp
- wire new demo into router and navigation
- style menu items

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c37a3ef564832b86840b88b34fd86b