### PR TITLE
docs: add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 
 # Telegram WebApp SDK
 
-[![crates.io](https://img.shields.io/crates/v/telegram-webapp-sdk.svg)](https://crates.io/crates/telegram-webapp-sdk)
-[![docs.rs](https://docs.rs/telegram-webapp-sdk/badge.svg)](https://docs.rs/telegram-webapp-sdk)
-[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](#license)
+[![Crates.io](https://img.shields.io/crates/v/telegram-webapp-sdk)](https://crates.io/crates/telegram-webapp-sdk)
+[![docs.rs](https://img.shields.io/docsrs/telegram-webapp-sdk)](https://docs.rs/telegram-webapp-sdk)
+[![Downloads](https://img.shields.io/crates/d/telegram-webapp-sdk)](https://crates.io/crates/telegram-webapp-sdk)
+![MSRV](https://img.shields.io/badge/MSRV-1.89-blue)
+![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+[![CI](https://github.com/RAprogramm/telegram-webapp-sdk/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/telegram-webapp-sdk/actions/workflows/ci.yml?query=branch%3Amain)
 
 `telegram-webapp-sdk` provides a type-safe and ergonomic wrapper around the [Telegram Web Apps](https://core.telegram.org/bots/webapps) JavaScript API.
 

--- a/src/leptos.rs
+++ b/src/leptos.rs
@@ -14,7 +14,7 @@ use crate::core::{context::TelegramContext, safe_context::get_context};
 ///
 /// ```no_run
 /// use leptos::prelude::*;
-/// use telegram_webapp_sdk::leptos::provide_telegram_context;
+/// use telegram_webapp_sdk::{core::context::TelegramContext, leptos::provide_telegram_context};
 ///
 /// #[component]
 /// fn App() -> impl IntoView {


### PR DESCRIPTION
## Summary
- add crate, downloads, MSRV, license, and CI badges
- fix Leptos doc example import

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -p telegram-webapp-sdk --all-targets --all-features -- -D warnings`
- `cargo build --all-targets -p telegram-webapp-sdk`
- `cargo test -p telegram-webapp-sdk --all-features`
- `cargo doc --no-deps -p telegram-webapp-sdk`


------
https://chatgpt.com/codex/tasks/task_e_68c3807f98d0832bb6e88b70faf88fcc