### PR TITLE
fix: specify rust version for demo crate

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "demo"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 wasm-bindgen = "0.2"


### PR DESCRIPTION
## Summary
- inherit rust version for demo crate to satisfy workflow

## Testing
- `cargo +nightly fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68c3835151d8832b8289fcb46ffd0fc2