### PR TITLE
feat: macros for easy Telegram mini app setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "convert_case 0.6.0",
  "pathdiff",
  "serde",
- "toml",
+ "toml 0.9.5",
  "winnow 0.7.13",
 ]
 
@@ -1265,6 +1265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2088,6 +2097,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
@@ -2320,6 +2338,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hmac-sha256",
+ "inventory",
  "js-sys",
  "leptos",
  "masterror",
@@ -2329,13 +2348,24 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "serde_urlencoded",
+ "telegram-webapp-sdk-macros",
  "thiserror 2.0.16",
+ "toml 0.8.23",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
  "yew",
+]
+
+[[package]]
+name = "telegram-webapp-sdk-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2424,12 +2454,24 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
  "toml_parser",
  "winnow 0.7.13",
@@ -2440,6 +2482,9 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -2462,6 +2507,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.13",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2528,12 @@ checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow 0.7.13",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ ed25519-dalek = "2"
 thiserror = "2"
 masterror = "0.3"
 urlencoding = { version = "2", optional = true }
+inventory = { version = "0.3", optional = true }
+telegram-webapp-sdk-macros = { path = "telegram-webapp-sdk-macros", optional = true }
+toml = "0.8"
 
 [dependencies.yew]
 version = "0.21"
@@ -60,12 +63,13 @@ features = ["csr"]
 
 [features]
 default = []
+macros = ["dep:telegram-webapp-sdk-macros", "dep:inventory"]
 yew = ["dep:yew"]
 leptos = ["dep:leptos"]
 mock = ["dep:urlencoding"]
 
 [workspace]
-members = ["demo"]
+members = ["demo", "telegram-webapp-sdk-macros"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@
 
 - Comprehensive coverage of Telegram Web App JavaScript APIs.
 - Framework integrations for **Yew** and **Leptos**.
+- Optional macros for automatic initialization and routing.
+
+## Macros
+
+The macros are available with the `macros` feature. Enable it in your `Cargo.toml`:
+
+```toml
+telegram-webapp-sdk = { version = "0.1", features = ["macros"] }
+```
+
+Reduce boilerplate in Telegram Mini Apps using the provided macros:
+
+```rust,ignore
+use telegram_webapp_sdk::{telegram_app, telegram_page, telegram_router};
+
+#[telegram_page("/")]
+fn index() {
+    // render page
+}
+
+#[telegram_app]
+fn main() -> Result<(), wasm_bindgen::JsValue> {
+    telegram_router!();
+    Ok(())
+}
+```
+
+When running outside Telegram in debug builds, `#[telegram_app]` loads mock
+settings from `telegram-webapp.toml`.
 - Configurable mock `Telegram.WebApp` for local development and testing.
 - API helpers for user interactions, storage, device sensors and more.
 
@@ -44,9 +73,10 @@ telegram-webapp-sdk = "0.1"
 Enable optional features as needed:
 
 ```toml
-telegram-webapp-sdk = { version = "0.1", features = ["yew", "mock"] }
+telegram-webapp-sdk = { version = "0.1", features = ["macros", "yew", "mock"] }
 ```
 
+- `macros` &mdash; enables `#[telegram_app]`, `#[telegram_page]`, and `telegram_router!`.
 - `yew` &mdash; exposes a `use_telegram_context` hook.
 - `leptos` &mdash; integrates the context into the Leptos reactive system.
 - `mock` &mdash; installs a configurable mock `Telegram.WebApp` for local development.

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -19,7 +19,7 @@ web-sys = { version = "0.3", features = [
   "console",
   "Text",
 ] }
-telegram-webapp-sdk = { path = "../", features = ["mock"] }
+telegram-webapp-sdk = { path = "../", features = ["mock", "macros"] }
 masterror = "0.3"
 
 [[bin]]

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -5,64 +5,13 @@ pub mod pages;
 pub mod router;
 
 use components::dev_menu::setup_dev_menu;
-use pages::{
-    burger_king::render_burger_king_page, index::render_index_page,
-    init_data::render_init_data_page, launch_params::render_launch_params_page,
-    theme_params::render_theme_params_page
-};
 use router::Router;
-use telegram_webapp_sdk::{
-    core::init::init_sdk,
-    mock::{config::MockTelegramConfig, data::MockTelegramUser, init::mock_telegram_webapp},
-    utils::check_env::is_telegram_env
-};
+use telegram_webapp_sdk::{telegram_app, telegram_router};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen(start)]
+#[telegram_app]
 pub fn main() -> Result<(), JsValue> {
-    if !is_telegram_env() {
-        #[cfg(debug_assertions)]
-        mock_telegram_webapp(MockTelegramConfig {
-            user: Some(MockTelegramUser {
-                id: 777,
-                first_name: "Alice".into(),
-                username: Some("alice_dev".into()),
-                is_premium: Some(true),
-                ..Default::default()
-            }),
-            auth_date: Some("1234567890".into()),
-            hash: Some("fakehash".into()),
-            bg_color: Some("#ffffff".into()),
-            text_color: Some("#000000".into()),
-            hint_color: Some("#888888".into()),
-            link_color: Some("#2689bf".into()),
-            button_color: Some("#0088cc".into()),
-            button_text_color: Some("#ffffff".into()),
-            secondary_bg_color: Some("#f0f0f0".into()),
-            header_bg_color: Some("#1d1f21".into()),
-            bottom_bar_bg_color: Some("#1f2226".into()),
-            accent_text_color: Some("#2eaee3".into()),
-            section_bg_color: Some("#222529".into()),
-            section_header_text_color: Some("#c8c9cb".into()),
-            section_separator_color: Some("#2a2c30".into()),
-            subtitle_text_color: Some("#909398".into()),
-            destructive_text_color: Some("#e33e3e".into()),
-            ..Default::default()
-        })
-        .unwrap();
-    }
-
-    init_sdk()?;
-
     setup_dev_menu();
-
-    Router::new()
-        .register("/", render_index_page)
-        .register("/init-data", render_init_data_page)
-        .register("/launch-params", render_launch_params_page)
-        .register("/theme-params", render_theme_params_page)
-        .register("/burger-king", render_burger_king_page)
-        .start();
-
+    telegram_router!();
     Ok(())
 }

--- a/demo/src/pages/burger_king.rs
+++ b/demo/src/pages/burger_king.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::{logger, webapp::TelegramWebApp};
+use telegram_webapp_sdk::{logger, telegram_page, webapp::TelegramWebApp};
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::{Document, Element, HtmlElement, window};
 
@@ -23,6 +23,7 @@ impl MenuItem {
 }
 
 /// Render Burger King menu page with order buttons.
+#[telegram_page("/burger-king")]
 pub fn render_burger_king_page() {
     let page = PageLayout::with_header("Burger King Demo", "Burger King Menu");
 

--- a/demo/src/pages/index.rs
+++ b/demo/src/pages/index.rs
@@ -1,8 +1,10 @@
+use telegram_webapp_sdk::telegram_page;
 use web_sys::Element;
 
 use crate::components::{nav_link::nav_link, page_layout::PageLayout};
 
 /// Renders the index (home) page with navigation links.
+#[telegram_page("/")]
 pub fn render_index_page() {
     clear_app_root();
 

--- a/demo/src/pages/init_data.rs
+++ b/demo/src/pages/init_data.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::core::safe_context::get_context;
+use telegram_webapp_sdk::{core::safe_context::get_context, telegram_page};
 use wasm_bindgen::JsValue;
 
 use crate::components::{
@@ -7,6 +7,7 @@ use crate::components::{
 };
 
 /// Renders the Init Data page
+#[telegram_page("/init-data")]
 pub fn render_init_data_page() {
     let layout = PageLayout::new("Init Data");
 

--- a/demo/src/pages/launch_params.rs
+++ b/demo/src/pages/launch_params.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::core::context::get_launch_params;
+use telegram_webapp_sdk::{core::context::get_launch_params, telegram_page};
 use wasm_bindgen::JsValue;
 
 use crate::components::{
@@ -7,6 +7,7 @@ use crate::components::{
 };
 
 /// Renders the Launch Parameters page.
+#[telegram_page("/launch-params")]
 pub fn render_launch_params_page() {
     super::index::clear_app_root();
 

--- a/demo/src/pages/theme_params.rs
+++ b/demo/src/pages/theme_params.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::core::safe_context::get_context;
+use telegram_webapp_sdk::{core::safe_context::get_context, telegram_page};
 use wasm_bindgen::JsValue;
 
 use crate::components::{
@@ -7,6 +7,7 @@ use crate::components::{
 };
 
 /// Renders the Theme Parameters page.
+#[telegram_page("/theme-params")]
 pub fn render_theme_params_page() {
     super::index::clear_app_root();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,11 @@ pub mod utils;
 pub mod webapp;
 pub use utils::validate_init_data;
 pub use webapp::TelegramWebApp;
+#[cfg(feature = "macros")]
+pub mod pages;
+
+#[cfg(feature = "macros")]
+pub use telegram_webapp_sdk_macros::{telegram_app, telegram_page, telegram_router};
 
 #[cfg(feature = "yew")]
 pub mod yew;

--- a/src/mock/config.rs
+++ b/src/mock/config.rs
@@ -1,6 +1,14 @@
+use std::{
+    fs,
+    io::{Error, ErrorKind}
+};
+
+use serde::Deserialize;
+
 use super::data::MockTelegramUser;
 
-#[derive(Default)]
+/// Configuration for mocking Telegram environment.
+#[derive(Default, Deserialize)]
 pub struct MockTelegramConfig {
     pub user: Option<MockTelegramUser>,
     pub auth_date: Option<String>,
@@ -22,4 +30,28 @@ pub struct MockTelegramConfig {
     pub destructive_text_color: Option<String>,
     pub platform: Option<String>,
     pub version: Option<String>
+}
+
+impl MockTelegramConfig {
+    /// Loads configuration from a TOML file.
+    pub fn from_file(path: &str) -> Result<Self, Error> {
+        let content = fs::read_to_string(path)?;
+        toml::from_str(&content).map_err(|e| Error::new(ErrorKind::InvalidData, e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_user_from_file() {
+        let cfg = MockTelegramConfig::from_file("telegram-webapp.toml").expect("config");
+        assert_eq!(cfg.user.unwrap().first_name, "Alice");
+    }
+
+    #[test]
+    fn missing_file_is_error() {
+        assert!(MockTelegramConfig::from_file("nope.toml").is_err());
+    }
 }

--- a/src/mock/data.rs
+++ b/src/mock/data.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct MockTelegramUser {
     pub id:                 u64,
     pub first_name:         String,

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,0 +1,15 @@
+use inventory::collect;
+
+/// Represents a single routable page.
+#[derive(Copy, Clone)]
+pub struct Page {
+    pub path:    &'static str,
+    pub handler: fn()
+}
+
+collect!(Page);
+
+/// Returns iterator over registered pages.
+pub fn iter() -> inventory::iter<Page> {
+    inventory::iter::<Page>
+}

--- a/telegram-webapp-sdk-macros/Cargo.toml
+++ b/telegram-webapp-sdk-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "telegram-webapp-sdk-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/telegram-webapp-sdk-macros/src/lib.rs
+++ b/telegram-webapp-sdk-macros/src/lib.rs
@@ -1,0 +1,53 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{ItemFn, LitStr, parse_macro_input};
+
+#[proc_macro_attribute]
+pub fn telegram_page(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let path = parse_macro_input!(attr as LitStr);
+    let input = parse_macro_input!(item as ItemFn);
+    let name = &input.sig.ident;
+    let expanded = quote! {
+        #[::inventory::submit(::telegram_webapp_sdk::pages::Page { path: #path, handler: #name })]
+        #input
+    };
+    expanded.into()
+}
+
+#[proc_macro_attribute]
+pub fn telegram_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+    let vis = &input.vis;
+    let attrs = &input.attrs;
+    let sig = &input.sig;
+    let block = &input.block;
+    let expanded = quote! {
+        #[::wasm_bindgen::prelude::wasm_bindgen(start)]
+        #(#attrs)*
+        #vis #sig {
+            if !::telegram_webapp_sdk::utils::check_env::is_telegram_env() {
+                #[cfg(debug_assertions)]
+                if let Ok(cfg) = ::telegram_webapp_sdk::mock::config::MockTelegramConfig::from_file("telegram-webapp.toml") {
+                    let _ = ::telegram_webapp_sdk::mock::init::mock_telegram_webapp(cfg);
+                }
+            }
+            ::telegram_webapp_sdk::core::init::init_sdk()?;
+            #block
+        }
+    };
+    expanded.into()
+}
+
+#[proc_macro]
+pub fn telegram_router(_item: TokenStream) -> TokenStream {
+    let expanded = quote! {
+        {
+            let mut router = Router::new();
+            for page in ::telegram_webapp_sdk::pages::iter() {
+                router = router.register(page.path, page.handler);
+            }
+            router.start();
+        }
+    };
+    expanded.into()
+}

--- a/telegram-webapp.toml
+++ b/telegram-webapp.toml
@@ -1,0 +1,27 @@
+# Example configuration for mock Telegram environment
+
+[user]
+id = 777
+first_name = "Alice"
+username = "alice_dev"
+is_premium = true
+
+auth_date = "1234567890"
+hash = "fakehash"
+bg_color = "#ffffff"
+text_color = "#000000"
+hint_color = "#888888"
+link_color = "#2689bf"
+button_color = "#0088cc"
+button_text_color = "#ffffff"
+secondary_bg_color = "#f0f0f0"
+header_bg_color = "#1d1f21"
+bottom_bar_bg_color = "#1f2226"
+accent_text_color = "#2eaee3"
+section_bg_color = "#222529"
+section_header_text_color = "#c8c9cb"
+section_separator_color = "#2a2c30"
+subtitle_text_color = "#909398"
+destructive_text_color = "#e33e3e"
+platform = "web"
+version = "6.0"


### PR DESCRIPTION
## Summary
- add procedural macros for auto initialization and routing
- support mock configuration via `telegram-webapp.toml`
- simplify demo with macro-based router
- gate macros behind an optional feature

## Testing
- `cargo +nightly fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo build --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_68c3a893f4d0832b8a038cd9aacde29c