### PR TITLE
Fix page registration macro to use inventory submit

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -4,9 +4,13 @@ pub mod components;
 pub mod pages;
 pub mod router;
 
-use components::dev_menu::setup_dev_menu;
-use router::Router;
+use telegram_webapp_sdk::{telegram_app, telegram_router};
 use wasm_bindgen::prelude::*;
+
+#[rustfmt::skip]
+use components::dev_menu::setup_dev_menu;
+#[rustfmt::skip]
+use router::Router;
 
 telegram_app!(
     pub fn main() -> Result<(), JsValue> {

--- a/demo/src/pages/burger_king.rs
+++ b/demo/src/pages/burger_king.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::{logger, webapp::TelegramWebApp};
+use telegram_webapp_sdk::{logger, telegram_page, webapp::TelegramWebApp};
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::{Document, Element, HtmlElement, window};
 

--- a/demo/src/pages/index.rs
+++ b/demo/src/pages/index.rs
@@ -1,3 +1,4 @@
+use telegram_webapp_sdk::telegram_page;
 use web_sys::Element;
 
 use crate::components::{nav_link::nav_link, page_layout::PageLayout};

--- a/demo/src/pages/init_data.rs
+++ b/demo/src/pages/init_data.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::core::safe_context::get_context;
+use telegram_webapp_sdk::{core::safe_context::get_context, telegram_page};
 use wasm_bindgen::JsValue;
 
 use crate::components::{

--- a/demo/src/pages/launch_params.rs
+++ b/demo/src/pages/launch_params.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::core::context::get_launch_params;
+use telegram_webapp_sdk::{core::context::get_launch_params, telegram_page};
 use wasm_bindgen::JsValue;
 
 use crate::components::{

--- a/demo/src/pages/theme_params.rs
+++ b/demo/src/pages/theme_params.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::core::safe_context::get_context;
+use telegram_webapp_sdk::{core::safe_context::get_context, telegram_page};
 use wasm_bindgen::JsValue;
 
 use crate::components::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod logger;
 pub mod mock;
 pub mod utils;
 pub mod webapp;
+#[cfg(feature = "macros")]
+pub use inventory;
 pub use utils::validate_init_data;
 pub use webapp::TelegramWebApp;
 #[cfg(feature = "macros")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,8 +14,11 @@
 macro_rules! telegram_page {
     ($path:literal, $(#[$meta:meta])* $vis:vis fn $name:ident $($rest:tt)*) => {
         $(#[$meta])*
-        #[::inventory::submit($crate::pages::Page { path: $path, handler: $name })]
         $vis fn $name $($rest)*
+
+        $crate::inventory::submit! {
+            $crate::pages::Page { path: $path, handler: $name }
+        }
     };
 }
 


### PR DESCRIPTION
## Summary
- register pages after handler definition using `inventory::submit!`
- re-export `inventory` so macro consumers don't depend on it directly
- import macros in demo pages for compilation

## Testing
- `cargo clippy --all -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c4a439a110832b82834e056f17bd19