### PR TITLE
docs: link API coverage entries

### DIFF
--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -39,7 +39,7 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] checkHomeScreenStatus ([e709edb](https://github.com/RAprogramm/telegram-webapp-sdk/commit/e709edb))
 - [x] enableClosingConfirmation ([8fe4dec](https://github.com/RAprogramm/telegram-webapp-sdk/commit/8fe4dec))
 - [x] disableClosingConfirmation ([8fe4dec](https://github.com/RAprogramm/telegram-webapp-sdk/commit/8fe4dec))
-- [x] isClosingConfirmationEnabled (unreleased)
+- [x] isClosingConfirmationEnabled ([99a3cf2](https://github.com/RAprogramm/telegram-webapp-sdk/commit/99a3cf2))
 - [x] requestFullscreen ([4364008](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4364008))
 - [x] exitFullscreen ([4364008](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4364008))
 - [x] lockOrientation ([4364008](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4364008))
@@ -124,7 +124,7 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] setItem ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] removeItem ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] getItems ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
-- [x] setItems
+- [x] setItems ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] removeItems ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] getKeys ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] clear ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))


### PR DESCRIPTION
## Summary
- reference commits for `setItems` and `isClosingConfirmationEnabled` in API coverage

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68c4b49768a0832b8b54540d9fde2956