### PR TITLE
Add minimal router and integrate telegram_router macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,33 @@ settings from `telegram-webapp.toml`.
 - Configurable mock `Telegram.WebApp` for local development and testing.
 - API helpers for user interactions, storage, device sensors and more.
 
+## Router
+
+The `macros` feature ships with a minimal in-memory [`Router`](src/router.rs)
+that collects pages registered via `telegram_page!`. The
+[`telegram_router!`](src/macros.rs) macro builds this router and runs all page
+handlers:
+
+```rust,ignore
+telegram_page!("/", pub fn index() {});
+
+// Uses the default Router
+telegram_router!();
+```
+
+Provide a custom router type to the macro if additional behavior is required:
+
+```rust,ignore
+struct CustomRouter;
+impl CustomRouter {
+    fn new() -> Self { CustomRouter }
+    fn register(self, _path: &str, _handler: fn()) -> Self { self }
+    fn start(self) {}
+}
+
+telegram_router!(CustomRouter);
+```
+
 ## Table of contents
 
 - [Installation](#installation)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub use webapp::TelegramWebApp;
 mod macros;
 #[cfg(feature = "macros")]
 pub mod pages;
+#[cfg(feature = "macros")]
+pub mod router;
 
 #[cfg(feature = "yew")]
 pub mod yew;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,75 @@
+//! Simple in-memory page router.
+//!
+//! Collects [`crate::pages::Page`] items and executes their handlers in
+//! registration order. Used by [`telegram_router!`](crate::telegram_router)
+//! macro by default.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use telegram_webapp_sdk::router::Router;
+//!
+//! fn index() {}
+//!
+//! Router::new().register("/", index).start();
+//! ```
+
+use crate::pages::Page;
+
+/// Sequential router executing registered page handlers.
+#[derive(Default)]
+pub struct Router {
+    pages: Vec<Page>
+}
+
+impl Router {
+    /// Creates an empty router.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a page handler associated with `path` and returns the updated
+    /// router.
+    pub fn register(mut self, path: &'static str, handler: fn()) -> Self {
+        self.pages.push(Page {
+            path,
+            handler
+        });
+        self
+    }
+
+    /// Starts the router, invoking handlers in order of registration.
+    pub fn start(self) {
+        for page in self.pages {
+            (page.handler)();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn noop() {}
+
+    #[test]
+    fn registers_pages() {
+        let router = Router::new().register("/", noop);
+        assert_eq!(router.pages.len(), 1);
+    }
+
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    fn handler() {
+        COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn starts_registered_pages() {
+        COUNT.store(0, Ordering::SeqCst);
+        Router::new().register("/", handler).start();
+        assert_eq!(COUNT.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add simple Router collecting registered pages
- export router module and update `telegram_router!` to use it by default
- document router and expand README

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features macros -- -D warnings`
- `cargo build --all-targets`
- `cargo build --all-targets --features macros`
- `cargo test --all`
- `cargo test --all --features macros`
- `cargo doc --no-deps --features macros`


------
https://chatgpt.com/codex/tasks/task_e_68c4c781df08832b9d9a5b8d40cc41f8