### PR TITLE
Add macros for standard Telegram DOM elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ web-sys = { version = "0.3", features = [
   "Document",
   "Element",
   "HtmlElement",
+  "HtmlImageElement",
   "console",
   "Location",
   "CssStyleDeclaration",

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -10,6 +10,7 @@ web-sys = { version = "0.3", features = [
   "Window",
   "Document",
   "HtmlElement",
+  "HtmlImageElement",
   "History",
   "Location",
   "Event",

--- a/demo/src/pages/burger_king.rs
+++ b/demo/src/pages/burger_king.rs
@@ -1,6 +1,6 @@
-use telegram_webapp_sdk::{logger, telegram_page, webapp::TelegramWebApp};
-use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
-use web_sys::{Document, Element, HtmlElement, window};
+use telegram_webapp_sdk::{logger, telegram_button, telegram_page, webapp::TelegramWebApp};
+use wasm_bindgen::{JsValue, prelude::Closure};
+use web_sys::{Document, Element, window};
 
 use crate::components::page_layout::PageLayout;
 
@@ -68,9 +68,7 @@ fn render_item(item: &MenuItem) -> Result<Element, JsValue> {
     ));
     container.append_child(&label)?;
 
-    let button = document.create_element("button")?;
-    button.set_inner_html("Order");
-    let button_el: HtmlElement = button.clone().dyn_into()?;
+    let button_el = telegram_button!(document, "Order", class = "order-button")?;
 
     let item_clone = item.clone();
     let click = Closure::<dyn FnMut()>::new(move || {

--- a/demo/src/pages/index.rs
+++ b/demo/src/pages/index.rs
@@ -1,4 +1,4 @@
-use telegram_webapp_sdk::telegram_page;
+use telegram_webapp_sdk::{telegram_image, telegram_page};
 use web_sys::Element;
 
 use crate::components::{nav_link::nav_link, page_layout::PageLayout};
@@ -10,6 +10,16 @@ telegram_page!(
         clear_app_root();
 
         let page = PageLayout::new("Telegram WebApp SDK Demo");
+
+        let document = web_sys::window().unwrap().document().unwrap();
+        let logo = telegram_image!(
+            document,
+            "https://telegram.org/img/t_logo.png",
+            class = "logo",
+            alt = "Telegram logo"
+        )
+        .unwrap();
+        page.append(logo.as_ref());
 
         let features_header = section_header("Features");
         page.append(&features_header);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ pub use webapp::TelegramWebApp;
 mod macros;
 #[cfg(feature = "macros")]
 pub mod pages;
+#[cfg(feature = "macros")]
+#[allow(unused_imports)]
+pub use crate::macros::*;
 
 #[cfg(feature = "yew")]
 pub mod yew;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -215,3 +215,84 @@ macro_rules! telegram_router {
         router.start();
     }};
 }
+
+/// Create a `<button>` element.
+///
+/// Generates a [`web_sys::HtmlElement`] with the provided text, optional CSS
+/// class and arbitrary attributes. The macro evaluates to
+/// `Result<web_sys::HtmlElement, wasm_bindgen::JsValue>` so it can be used with
+/// the `?` operator inside functions returning `Result`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use telegram_webapp_sdk::telegram_button;
+/// use wasm_bindgen::JsValue;
+///
+/// # fn example() -> Result<(), JsValue> {
+/// let document = web_sys::window()
+///     .and_then(|w| w.document())
+///     .ok_or_else(|| JsValue::from_str("no document"))?;
+/// let button = telegram_button!(document, "Click", class = "primary", "type" = "button")?;
+/// assert_eq!(button.tag_name(), "BUTTON");
+/// # Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! telegram_button {
+    ($doc:expr, $text:expr $(, class = $class:expr)? $(, $attr:literal = $value:expr)* $(,)?) => {{
+        || -> Result<web_sys::HtmlElement, wasm_bindgen::JsValue> {
+            use wasm_bindgen::JsCast;
+            let element = $doc.create_element("button")?;
+            element.set_inner_html($text);
+            $(element.set_class_name($class);)?
+            $(
+                element.set_attribute($attr, $value)?;
+            )*
+            element
+                .dyn_into::<web_sys::HtmlElement>()
+                .map_err(wasm_bindgen::JsValue::from)
+        }()
+    }};
+}
+
+/// Create an `<img>` element.
+///
+/// Generates a [`web_sys::HtmlImageElement`] with the provided `src`, optional
+/// CSS class, `alt` text and additional attributes. Like
+/// [`telegram_button!`], this macro yields a `Result` for ergonomic error
+/// propagation.
+///
+/// # Examples
+///
+/// ```ignore
+/// use telegram_webapp_sdk::telegram_image;
+/// use wasm_bindgen::JsValue;
+///
+/// # fn example() -> Result<(), JsValue> {
+/// let document = web_sys::window()
+///     .and_then(|w| w.document())
+///     .ok_or_else(|| JsValue::from_str("no document"))?;
+/// let image = telegram_image!(document, "/logo.png", class = "logo", alt = "Logo")?;
+/// assert_eq!(image.tag_name(), "IMG");
+/// # Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! telegram_image {
+    ($doc:expr, $src:expr $(, class = $class:expr)? $(, alt = $alt:expr)? $(, $attr:literal = $value:expr)* $(,)?) => {{
+        || -> Result<web_sys::HtmlImageElement, wasm_bindgen::JsValue> {
+            use wasm_bindgen::JsCast;
+            let element = $doc.create_element("img")?;
+            element.set_attribute("src", $src)?;
+            $(element.set_class_name($class);)?
+            $(element.set_attribute("alt", $alt)?;)?
+            $(
+                element.set_attribute($attr, $value)?;
+            )*
+            element
+                .dyn_into::<web_sys::HtmlImageElement>()
+                .map_err(wasm_bindgen::JsValue::from)
+        }()
+    }};
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,35 @@
+#![cfg(all(target_arch = "wasm32", feature = "macros"))]
+
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn telegram_button_creates_button() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let button =
+        telegram_webapp_sdk::telegram_button!(document, "OK", class = "btn", "type" = "button")
+            .unwrap();
+    assert_eq!(button.tag_name(), "BUTTON");
+    assert_eq!(button.class_name(), "btn");
+    assert_eq!(button.get_attribute("type").unwrap(), "button");
+}
+
+#[wasm_bindgen_test]
+fn telegram_image_creates_image() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let img = telegram_webapp_sdk::telegram_image!(
+        document,
+        "https://example.com/logo.png",
+        class = "pic",
+        alt = "Logo"
+    )
+    .unwrap();
+    assert_eq!(img.tag_name(), "IMG");
+    assert_eq!(img.class_name(), "pic");
+    assert_eq!(
+        img.get_attribute("src").unwrap(),
+        "https://example.com/logo.png"
+    );
+    assert_eq!(img.get_attribute("alt").unwrap(), "Logo");
+}


### PR DESCRIPTION
## Summary
- add `telegram_button!` and `telegram_image!` macros generating `web_sys` elements with attributes
- expose new macros when the `macros` feature is enabled
- update demo to use the new macros
- cover macros with wasm-bindgen tests and docs

## Testing
- `cargo clippy --all-targets --features macros -- -D warnings`
- `cargo build --all-targets --features macros`
- `cargo test --all`
- `cargo test --all --features macros --target wasm32-unknown-unknown` *(fails: no WebDriver)*
- `cargo doc --no-deps --features macros`


------
https://chatgpt.com/codex/tasks/task_e_68c4c78ba948832b9dcfc0112d26a8da