### PR TITLE
Fix Leptos bottom button callback cleanup and demo build

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -5,7 +5,6 @@ pub mod pages;
 pub mod router;
 
 use components::dev_menu::setup_dev_menu;
-use router::Router;
 use telegram_webapp_sdk::{telegram_app, telegram_router};
 use wasm_bindgen::prelude::*;
 

--- a/demo/src/pages/burger_king.rs
+++ b/demo/src/pages/burger_king.rs
@@ -1,5 +1,5 @@
 use telegram_webapp_sdk::{logger, telegram_button, telegram_page, webapp::TelegramWebApp};
-use wasm_bindgen::{JsValue, prelude::Closure};
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::{Document, Element, window};
 
 use crate::components::page_layout::PageLayout;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,8 +1,7 @@
 //! Simple in-memory page router.
 //!
-//! Collects [`crate::pages::Page`] items and executes their handlers in
-//! registration order. Used by [`telegram_router!`](crate::telegram_router)
-//! macro by default.
+//! Collects page definitions and executes their handlers in registration
+//! order. Used by the `telegram_router!` macro by default.
 //!
 //! # Examples
 //!
@@ -14,7 +13,15 @@
 //! Router::new().register("/", index).start();
 //! ```
 
+#[cfg(feature = "macros")]
 use crate::pages::Page;
+#[cfg(not(feature = "macros"))]
+#[derive(Copy, Clone)]
+struct Page {
+    #[allow(dead_code)]
+    path:    &'static str,
+    handler: fn()
+}
 
 /// Sequential router executing registered page handlers.
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- unregister Leptos bottom button callbacks on component cleanup and test it
- fix demo imports and web callback usage
- make router compile without `macros` feature

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo audit`

------
https://chatgpt.com/codex/tasks/task_e_68c4d1964bf0832b9eda674feb486976