### PR TITLE
Avoid unwraps in macro tests and reduce cloning in theme parameters

### DIFF
--- a/src/core/types/theme_params.rs
+++ b/src/core/types/theme_params.rs
@@ -102,28 +102,47 @@ impl TelegramThemeParams {
     /// );
     /// ```
     pub fn into_css_vars(self) -> HashMap<String, String> {
+        self.css_vars_impl()
+    }
+
+    /// Returns all theme parameters as CSS custom properties without
+    /// consuming `self`.
+    pub fn css_vars(&self) -> HashMap<String, String> {
+        self.css_vars_impl()
+    }
+
+    fn css_vars_impl(&self) -> HashMap<String, String> {
         let mut vars: HashMap<String, String> = HashMap::with_capacity(16);
-        let mut push = |key: &str, value: Option<String>| {
+        let mut push = |key: &str, value: Option<&String>| {
             if let Some(v) = value {
-                vars.insert(format!("--tg-theme-{}", key), v);
+                vars.insert(format!("--tg-theme-{key}"), v.clone());
             }
         };
 
-        push("bg-color", self.bg_color);
-        push("text-color", self.text_color);
-        push("hint-color", self.hint_color);
-        push("link-color", self.link_color);
-        push("button-color", self.button_color);
-        push("button-text-color", self.button_text_color);
-        push("secondary-bg-color", self.secondary_bg_color);
-        push("header-bg-color", self.header_bg_color);
-        push("bottom-bar-bg-color", self.bottom_bar_bg_color);
-        push("accent-text-color", self.accent_text_color);
-        push("section-bg-color", self.section_bg_color);
-        push("section-header-text-color", self.section_header_text_color);
-        push("section-separator-color", self.section_separator_color);
-        push("subtitle-text-color", self.subtitle_text_color);
-        push("destructive-text-color", self.destructive_text_color);
+        push("bg-color", self.bg_color.as_ref());
+        push("text-color", self.text_color.as_ref());
+        push("hint-color", self.hint_color.as_ref());
+        push("link-color", self.link_color.as_ref());
+        push("button-color", self.button_color.as_ref());
+        push("button-text-color", self.button_text_color.as_ref());
+        push("secondary-bg-color", self.secondary_bg_color.as_ref());
+        push("header-bg-color", self.header_bg_color.as_ref());
+        push("bottom-bar-bg-color", self.bottom_bar_bg_color.as_ref());
+        push("accent-text-color", self.accent_text_color.as_ref());
+        push("section-bg-color", self.section_bg_color.as_ref());
+        push(
+            "section-header-text-color",
+            self.section_header_text_color.as_ref()
+        );
+        push(
+            "section-separator-color",
+            self.section_separator_color.as_ref()
+        );
+        push("subtitle-text-color", self.subtitle_text_color.as_ref());
+        push(
+            "destructive-text-color",
+            self.destructive_text_color.as_ref()
+        );
 
         vars
     }
@@ -171,10 +190,7 @@ impl TelegramThemeParams {
     /// Returns all non‐empty theme parameters as a vector of
     /// `(css_variable_name, color_value)` pairs.
     pub fn to_map(&self) -> Vec<(String, String)> {
-        self.clone() // clone our struct
-            .into_css_vars() // move into a HashMap<String,String>
-            .into_iter() // turn that into an iterator of (String,String)
-            .collect() // collect into a Vec
+        self.css_vars_impl().into_iter().collect()
     }
 }
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,35 +1,46 @@
 #![cfg(all(target_arch = "wasm32", feature = "macros"))]
 
+use wasm_bindgen::JsValue;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn telegram_button_creates_button() {
-    let document = web_sys::window().unwrap().document().unwrap();
+fn telegram_button_creates_button() -> Result<(), JsValue> {
+    let document = web_sys::window()
+        .and_then(|w| w.document())
+        .ok_or_else(|| JsValue::from_str("no document"))?;
     let button =
-        telegram_webapp_sdk::telegram_button!(document, "OK", class = "btn", "type" = "button")
-            .unwrap();
+        telegram_webapp_sdk::telegram_button!(document, "OK", class = "btn", "type" = "button")?;
     assert_eq!(button.tag_name(), "BUTTON");
     assert_eq!(button.class_name(), "btn");
-    assert_eq!(button.get_attribute("type").unwrap(), "button");
+    let btn_type = button
+        .get_attribute("type")
+        .ok_or_else(|| JsValue::from_str("missing type attribute"))?;
+    assert_eq!(btn_type, "button");
+    Ok(())
 }
 
 #[wasm_bindgen_test]
-fn telegram_image_creates_image() {
-    let document = web_sys::window().unwrap().document().unwrap();
+fn telegram_image_creates_image() -> Result<(), JsValue> {
+    let document = web_sys::window()
+        .and_then(|w| w.document())
+        .ok_or_else(|| JsValue::from_str("no document"))?;
     let img = telegram_webapp_sdk::telegram_image!(
         document,
         "https://example.com/logo.png",
         class = "pic",
         alt = "Logo"
-    )
-    .unwrap();
+    )?;
     assert_eq!(img.tag_name(), "IMG");
     assert_eq!(img.class_name(), "pic");
-    assert_eq!(
-        img.get_attribute("src").unwrap(),
-        "https://example.com/logo.png"
-    );
-    assert_eq!(img.get_attribute("alt").unwrap(), "Logo");
+    let src = img
+        .get_attribute("src")
+        .ok_or_else(|| JsValue::from_str("missing src"))?;
+    assert_eq!(src, "https://example.com/logo.png");
+    let alt = img
+        .get_attribute("alt")
+        .ok_or_else(|| JsValue::from_str("missing alt"))?;
+    assert_eq!(alt, "Logo");
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace unwrap usage in wasm macro tests with proper error propagation
- Remove struct-wide clone by introducing non-consuming CSS var generation for theme params

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c4d7b5b3f8832b8dba6827eddfc86b