### PR TITLE
refactor: collapse nested if in bottom button cleanup

### DIFF
--- a/src/leptos/bottom_button.rs
+++ b/src/leptos/bottom_button.rs
@@ -116,10 +116,10 @@ where
     on_cleanup(move || {
         if let Some(app) = TelegramWebApp::instance() {
             BUTTON_HANDLES.with(|handles| {
-                if let Some(handle) = handles.borrow_mut().remove(&button) {
-                    if let Err(err) = app.remove_bottom_button_callback(handle) {
-                        logger::error(&format!("remove_bottom_button_callback failed: {err:?}"));
-                    }
+                if let Some(handle) = handles.borrow_mut().remove(&button)
+                    && let Err(err) = app.remove_bottom_button_callback(handle)
+                {
+                    logger::error(&format!("remove_bottom_button_callback failed: {err:?}"));
                 }
             });
             if let Err(err) = app.hide_bottom_button(button) {


### PR DESCRIPTION
## Summary
- collapse nested if blocks when removing a bottom button callback to satisfy clippy

## Testing
- `cargo build --all-targets`
- `cargo clippy -- -D warnings`
- `cargo test --all`
- `cargo doc --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_68c4d7fcd6f4832b851288570ed31ac1