### PR TITLE
Upgrade masterror to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2025-09-21
+### Changed
+- Upgraded to `masterror` 0.10 and refreshed internal tooling error handling to
+  accommodate the derive updates.
+
 ## [0.2.5] - 2025-09-20
 ### Changed
 - Replaced `thiserror` derives with the new `masterror::Error` re-export and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "demo"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "inventory",
  "masterror",
@@ -1639,16 +1639,35 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.0"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b969456c81bd3bd6b7f2c468ee95d5d6c5070050746e56f9ab4dd2a161b4ea55"
+checksum = "1a8b870429788ecb76b1070b592135bff852829e34db09e237e848a231048535"
 dependencies = [
  "http 1.3.1",
+ "masterror-derive",
+ "masterror-template",
  "serde",
- "thiserror 2.0.16",
  "toml",
  "tracing",
 ]
+
+[[package]]
+name = "masterror-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef013bb3e4e26e81cb15c88cc405833054faa4cc1005bc06778fddbd074d8973"
+dependencies = [
+ "masterror-template",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "masterror-template"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55940293fa5d7fc9e7defaf45097b5d502f2d9be4083901f5c255258c5a2bfdd"
 
 [[package]]
 name = "memchr"
@@ -2728,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.5"
+version = "0.2.6"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"
@@ -44,7 +44,7 @@ percent-encoding = "2"
 base64 = "0.22"
 ed25519-dalek = "2"
 "\u0074hiserror" = "2"
-masterror = "0.5"
+masterror = "0.10"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = [
   "blocking",

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demo"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 rust-version.workspace = true
 
@@ -21,7 +21,7 @@ web-sys = { version = "0.3", features = [
   "Text",
 ] }
 telegram-webapp-sdk = { path = "../", features = ["mock", "macros"] }
-masterror = "0.5"
+masterror = "0.10"
 inventory = "0.3.21"
 
 [[bin]]

--- a/src/bin/update_readme/main.rs
+++ b/src/bin/update_readme/main.rs
@@ -1,3 +1,8 @@
+#![allow(
+    non_shorthand_field_patterns,
+    reason = "derive-generated source access needs renames"
+)]
+
 mod version_probe;
 
 use std::{env, fs, path::PathBuf};
@@ -25,10 +30,11 @@ enum ReadmeUpdateError {
     MetadataParse(toml::de::Error),
     #[error("environment variable CARGO_MANIFEST_DIR not set: {0}")]
     ManifestDir(env::VarError),
-    #[error("failed to read file {path}: {source}")]
+    #[error("failed to read file {path}: {error}")]
     ReadFile {
-        path:   String,
-        source: std::io::Error
+        path:  String,
+        #[source]
+        error: std::io::Error
     },
     #[error("commit {commit} declared in metadata not found in WEBAPP_API.md")]
     CommitNotReferenced { commit: String },
@@ -99,19 +105,19 @@ fn run() -> Result<(), ReadmeUpdateError> {
     let cargo_toml_path = root.join("Cargo.toml");
 
     let webapp_api_content =
-        fs::read_to_string(&webapp_api_path).map_err(|source| ReadmeUpdateError::ReadFile {
+        fs::read_to_string(&webapp_api_path).map_err(|error| ReadmeUpdateError::ReadFile {
             path: webapp_api_path.display().to_string(),
-            source
+            error
         })?;
     let readme_content =
-        fs::read_to_string(&readme_path).map_err(|source| ReadmeUpdateError::ReadFile {
+        fs::read_to_string(&readme_path).map_err(|error| ReadmeUpdateError::ReadFile {
             path: readme_path.display().to_string(),
-            source
+            error
         })?;
     let cargo_toml_content =
-        fs::read_to_string(&cargo_toml_path).map_err(|source| ReadmeUpdateError::ReadFile {
+        fs::read_to_string(&cargo_toml_path).map_err(|error| ReadmeUpdateError::ReadFile {
             path: cargo_toml_path.display().to_string(),
-            source
+            error
         })?;
 
     let mut status = parse_status(&webapp_api_content)?;


### PR DESCRIPTION
## Summary
- bump the workspace crates to version 0.2.6 and upgrade masterror to 0.10.8
- adjust update_readme error handling to work with the new masterror derive output
- record the dependency update in the changelog

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check -d

------
https://chatgpt.com/codex/tasks/task_e_68cf42c44fb4832b9818d27666114284