### PR TITLE
Remove direct thiserror dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2025-09-21
+### Changed
+- Removed the crate's direct dependency on `thiserror`, relying on `masterror`
+  for error derives exclusively.
+
 ## [0.2.6] - 2025-09-21
 ### Changed
 - Upgraded to `masterror` 0.10 and refreshed internal tooling error handling to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2458,18 +2458,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2765,7 +2765,6 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.16",
  "toml",
  "urlencoding",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.6"
+version = "0.2.7"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"
@@ -43,7 +43,6 @@ hex = "0.4"
 percent-encoding = "2"
 base64 = "0.22"
 ed25519-dalek = "2"
-"\u0074hiserror" = "2"
 masterror = "0.10"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = [


### PR DESCRIPTION
## Summary
- drop the crate's direct `thiserror` dependency so the derive comes solely from `masterror`
- bump the crate version to 0.2.7 and record the change in the changelog
- regenerate `Cargo.lock` to remove the explicit `thiserror` entry and align dependency versions

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings`
- `cargo +1.90.0 build --all-targets`
- `cargo +1.90.0 test --all`
- `cargo +1.90.0 doc --no-deps`
- `cargo audit`
- `cargo deny check` *(fails: unable to fetch advisory database because the Git HTTPS request is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf48611e04832bb1b29656183f9a8a