### PR TITLE
Fix release workflow package lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,15 @@ jobs:
           if ! command -v jq >/dev/null 2>&1; then
             sudo apt-get update -y && sudo apt-get install -y jq
           fi
-          RV=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].rust_version // empty')
+          PKG_NAME="telegram-webapp-sdk"
+          METADATA=$(cargo metadata --no-deps --format-version=1)
+          if ! printf '%s\n' "$METADATA" | jq -e --arg name "$PKG_NAME" '.packages[] | select(.name == $name)' >/dev/null; then
+            echo "Package ${PKG_NAME} not found in Cargo metadata"
+            exit 1
+          fi
+          RV=$(printf '%s\n' "$METADATA" | jq -r --arg name "$PKG_NAME" '.packages[] | select(.name == $name) | .rust_version // empty')
           if [ -z "$RV" ]; then
-            echo "rust-version is not set in Cargo.toml"
+            echo "rust-version is not set in Cargo.toml for package ${PKG_NAME}"
             exit 1
           fi
           if [[ "$RV" =~ ^[0-9]+\.[0-9]+$ ]]; then
@@ -40,7 +46,17 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
-          FILE_VER=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')
+          PKG_NAME="telegram-webapp-sdk"
+          METADATA=$(cargo metadata --no-deps --format-version=1)
+          if ! printf '%s\n' "$METADATA" | jq -e --arg name "$PKG_NAME" '.packages[] | select(.name == $name)' >/dev/null; then
+            echo "Package ${PKG_NAME} not found in Cargo metadata"
+            exit 1
+          fi
+          FILE_VER=$(printf '%s\n' "$METADATA" | jq -r --arg name "$PKG_NAME" '.packages[] | select(.name == $name) | .version // empty')
+          if [ -z "$FILE_VER" ]; then
+            echo "version is not set in Cargo.toml for package ${PKG_NAME}"
+            exit 1
+          fi
           if [ "v${FILE_VER}" != "${TAG}" ]; then
             echo "Tag ${TAG} != Cargo.toml version v${FILE_VER}"
             exit 1


### PR DESCRIPTION
## Summary
- select the `telegram-webapp-sdk` package explicitly when reading metadata in the release workflow
- fail the workflow early if the package metadata is missing the expected fields

## Testing
- `GITHUB_REF=refs/tags/v0.2.8 GITHUB_OUTPUT=/tmp/github_output_test bash -eo pipefail <(sed -n '24,42p' .github/workflows/release.yml)` *(manually replicated in shell to ensure msrv extraction succeeds)*
- `GITHUB_REF=refs/tags/v0.2.8 bash -eo pipefail <(sed -n '47,63p' .github/workflows/release.yml)` *(manually replicated in shell to ensure tag/version validation succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68cf55bb55bc832b86eac441e7c4e55a