### PR TITLE
Fix launch param decoding and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2025-09-22
+### Fixed
+- Corrected launch parameter parsing to honor the first query entry,
+  percent-decode values (including `tgWebAppPlatform`), and preserve
+  boolean flags.
+
+### Added
+- Regression tests covering decoded query parameters for `get_launch_params`.
+
 ## [0.2.8] - 2025-09-21
 ### Changed
 - Expanded the README with appearance, viewport, and biometric examples while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.8"
+version = "0.2.9"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 The macros are available with the `macros` feature. Enable it in your `Cargo.toml`:
 
 ```toml
-telegram-webapp-sdk = { version = "0.2.8", features = ["macros"] }
+telegram-webapp-sdk = { version = "0.2.9", features = ["macros"] }
 ```
 
 Reduce boilerplate in Telegram Mini Apps using the provided macros:
@@ -105,7 +105,7 @@ telegram-webapp-sdk = "0.2"
 Enable optional features as needed:
 
 ```toml
-telegram-webapp-sdk = { version = "0.2.8", features = ["macros", "yew", "mock"] }
+telegram-webapp-sdk = { version = "0.2.9", features = ["macros", "yew", "mock"] }
 ```
 
 - `macros` &mdash; enables `telegram_app!`, `telegram_page!`, and `telegram_router!`.


### PR DESCRIPTION
## Summary
- decode launch parameters correctly by trimming the leading `?`, percent-decoding values, and honoring the first entry
- derive `tg_web_app_platform` from the decoded `tgWebAppPlatform` query parameter with a sensible default and document the behavior
- add regression coverage for launch parameter parsing and bump the crate version/documentation with changelog notes

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: network error when fetching advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c6dfc064832bb37ea38be7814b10