### PR TITLE
Parse initData query_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2025-09-22
+### Added
+- Propagated `query_id` from `initData` into `TelegramInitData` and exposed it
+  through the global context, including a wasm integration test that verifies
+  the parsed value.
+
+### Changed
+- Extended the mock environment and documentation to surface the optional
+  `query_id` parameter, ensuring examples highlight how to handle inline query
+  responses.
+
 ## [0.2.9] - 2025-09-22
 ### Fixed
 - Corrected launch parameter parsing to honor the first query entry,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.9"
+version = "0.2.10"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 The macros are available with the `macros` feature. Enable it in your `Cargo.toml`:
 
 ```toml
-telegram-webapp-sdk = { version = "0.2.9", features = ["macros"] }
+telegram-webapp-sdk = { version = "0.2.10", features = ["macros"] }
 ```
 
 Reduce boilerplate in Telegram Mini Apps using the provided macros:
@@ -105,7 +105,7 @@ telegram-webapp-sdk = "0.2"
 Enable optional features as needed:
 
 ```toml
-telegram-webapp-sdk = { version = "0.2.9", features = ["macros", "yew", "mock"] }
+telegram-webapp-sdk = { version = "0.2.10", features = ["macros", "yew", "mock"] }
 ```
 
 - `macros` &mdash; enables `telegram_app!`, `telegram_page!`, and `telegram_router!`.
@@ -124,6 +124,10 @@ use yew::prelude::*;
 #[function_component(App)]
 fn app() -> Html {
     let ctx = use_telegram_context().expect("context");
+    if let Some(query_id) = ctx.init_data.query_id.as_deref() {
+        // Handle inline query response with `answerWebAppQuery`.
+        let _ = query_id;
+    }
     html! { <span>{ ctx.init_data.auth_date }</span> }
 }
 ```
@@ -152,6 +156,10 @@ fn App() -> impl IntoView {
     provide_telegram_context().expect("context");
     let ctx = use_context::<telegram_webapp_sdk::core::context::TelegramContext>()
         .expect("context");
+    if let Some(query_id) = ctx.init_data.query_id.as_deref() {
+        // Handle inline query response with `answerWebAppQuery`.
+        let _ = query_id;
+    }
     view! { <span>{ ctx.init_data.auth_date }</span> }
 }
 ```

--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -58,7 +58,7 @@ pub fn init_sdk() -> Result<(), JsValue> {
 
     // === 3. Construct final typed initData ===
     let init_data = TelegramInitData {
-        query_id: None, // not available in urlencoded format
+        query_id: raw.query_id,
         user,
         receiver,
         chat,

--- a/src/core/types/init_data.rs
+++ b/src/core/types/init_data.rs
@@ -7,7 +7,11 @@ use super::{chat::TelegramChat, user::TelegramUser};
 /// `signature`.
 #[derive(Clone, Debug, Deserialize)]
 pub struct TelegramInitData {
-    /// Unique identifier for the current Mini App session.
+    /// Unique identifier for the current Mini App session provided via
+    /// `Telegram.WebApp.initData`.
+    ///
+    /// Present when the Mini App is launched from inline query results and can
+    /// be used to respond through `answerWebAppQuery`.
     pub query_id: Option<String>,
 
     /// Information about the current Telegram user.

--- a/src/core/types/init_data_internal.rs
+++ b/src/core/types/init_data_internal.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct TelegramInitDataInternal {
+    pub query_id:       Option<String>,
     pub user:           Option<String>,
     pub receiver:       Option<String>,
     pub chat:           Option<String>,

--- a/src/mock/config.rs
+++ b/src/mock/config.rs
@@ -13,6 +13,7 @@ pub struct MockTelegramConfig {
     pub user: Option<MockTelegramUser>,
     pub auth_date: Option<String>,
     pub hash: Option<String>,
+    pub query_id: Option<String>,
     pub bg_color: Option<String>,
     pub text_color: Option<String>,
     pub hint_color: Option<String>,

--- a/src/mock/init.rs
+++ b/src/mock/init.rs
@@ -45,7 +45,7 @@ pub fn mock_telegram_webapp(config: MockTelegramConfig) -> Result<(), JsValue> {
     let auth_date = config.auth_date.unwrap_or_else(|| "1234567890".into());
     let hash = config.hash.unwrap_or_else(|| "fakehash".into());
 
-    let init_data = generate_mock_init_data(&user, &auth_date, &hash);
+    let init_data = generate_mock_init_data(&user, &auth_date, &hash, config.query_id.as_deref());
     Reflect::set(&webapp, &"initData".into(), &JsValue::from_str(&init_data))?;
 
     let theme = Object::new();

--- a/src/mock/utils.rs
+++ b/src/mock/utils.rs
@@ -9,17 +9,36 @@ use crate::mock::data::MockTelegramUser;
 /// - `user`: Telegram user data (as `MockTelegramUser`)
 /// - `auth_date`: UNIX timestamp (as string, e.g., `"1234567890"`)
 /// - `hash`: mock hash string (can be `"fakehash"` or real value)
+/// - `query_id`: optional inline query identifier to embed in the payload
 ///
 /// # Returns
 /// Properly URL-encoded initData string for Telegram WebApp emulation.
-pub fn generate_mock_init_data(user: &MockTelegramUser, auth_date: &str, hash: &str) -> String {
+pub fn generate_mock_init_data(
+    user: &MockTelegramUser,
+    auth_date: &str,
+    hash: &str,
+    query_id: Option<&str>
+) -> String {
     let user_json = to_string(user).unwrap_or_else(|_| "{}".into());
     let encoded_user = encode(&user_json);
+    let mut init_data = String::with_capacity(64);
 
-    format!(
-        "user={}&auth_date={}&hash={}",
-        encoded_user, auth_date, hash
-    )
+    if let Some(id) = query_id {
+        init_data.push_str("query_id=");
+        init_data.push_str(encode(id).as_ref());
+        init_data.push('&');
+    }
+
+    init_data.push_str("user=");
+    init_data.push_str(encoded_user.as_ref());
+    init_data.push('&');
+    init_data.push_str("auth_date=");
+    init_data.push_str(auth_date);
+    init_data.push('&');
+    init_data.push_str("hash=");
+    init_data.push_str(hash);
+
+    init_data
 }
 
 #[cfg(test)]
@@ -35,10 +54,24 @@ mod tests {
         };
         let auth_date = "123456";
         let hash = "hash";
-        let data = generate_mock_init_data(&user, auth_date, hash);
+        let data = generate_mock_init_data(&user, auth_date, hash, None);
 
         assert!(data.contains("user="));
         assert!(data.contains("auth_date=123456"));
+        assert!(data.contains("hash=hash"));
+        assert!(!data.starts_with("query_id="));
+    }
+
+    #[test]
+    fn adds_query_id_when_present() {
+        let user = MockTelegramUser {
+            id: 1,
+            first_name: "Dev".into(),
+            ..Default::default()
+        };
+        let data = generate_mock_init_data(&user, "123456", "hash", Some("inline:42/ä"));
+
+        assert!(data.starts_with("query_id=inline%3A42%2F%C3%A4&"));
         assert!(data.contains("hash=hash"));
     }
 }

--- a/telegram-webapp.toml
+++ b/telegram-webapp.toml
@@ -8,6 +8,7 @@ is_premium = true
 
 auth_date = "1234567890"
 hash = "fakehash"
+query_id = "AA123456789"
 bg_color = "#ffffff"
 text_color = "#000000"
 hint_color = "#888888"

--- a/tests/init_sdk.rs
+++ b/tests/init_sdk.rs
@@ -1,0 +1,41 @@
+#![cfg(target_arch = "wasm32")]
+
+use js_sys::{Object, Reflect};
+use telegram_webapp_sdk::core::{context::TelegramContext, init::init_sdk};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::window;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn install_webapp(init_data: &str) -> Result<(), JsValue> {
+    let win = window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let telegram = Object::new();
+    let webapp = Object::new();
+
+    Reflect::set(&webapp, &"initData".into(), &JsValue::from_str(init_data))?;
+    Reflect::set(
+        &webapp,
+        &"themeParams".into(),
+        &JsValue::from(Object::new())
+    )?;
+
+    Reflect::set(&telegram, &"WebApp".into(), &webapp)?;
+    Reflect::set(&win, &"Telegram".into(), &telegram)?;
+
+    Ok(())
+}
+
+#[wasm_bindgen_test]
+fn init_sdk_propagates_query_id() -> Result<(), JsValue> {
+    install_webapp("query_id=inline-123&auth_date=1&hash=abc")?;
+
+    init_sdk()?;
+
+    let query_id = TelegramContext::get(|ctx| ctx.init_data.query_id.as_deref())
+        .ok_or_else(|| JsValue::from_str("context not initialized"))?;
+
+    assert_eq!(query_id, Some("inline-123"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- surface the `query_id` from raw `initData` by extending the internal struct and wiring it into `TelegramInitData`
- update the mock generator/configuration and documentation to emit and explain the inline query identifier
- add a wasm integration test covering `init_sdk` parsing and bump the crate version/changelog to 0.2.10

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check *(fails: unable to fetch advisory database in this environment)*
- cargo audit


------
https://chatgpt.com/codex/tasks/task_e_68d0cb0ebb1c832b95e36e85cb11835d