### PR TITLE
chore: upgrade masterror to 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13] - 2025-10-01
+### Changed
+- Upgraded to `masterror` 0.24 across the workspace, ensuring the SDK and demo
+  benefit from the latest error handling improvements.
+
 ## [0.2.12] - 2025-09-24
 ### Changed
 - Centralized the `masterror` 0.11 dependency in workspace metadata so all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,23 +1639,26 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.11.0"
+version = "0.24.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edd89b6a28dafd207e6cd1a944f6e38efc92ee4f22b2551201584e0999a35bb"
+checksum = "493edc7ee9f72e3e916245137e932956cf93a74000826edf40d5a7e52047676d"
 dependencies = [
  "http 1.3.1",
+ "itoa",
  "masterror-derive",
  "masterror-template",
+ "ryu",
  "serde",
+ "sha2",
  "toml",
- "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "masterror-derive"
-version = "0.6.6"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef013bb3e4e26e81cb15c88cc405833054faa4cc1005bc06778fddbd074d8973"
+checksum = "089ea04e298d0f3164ef0786fac312ed75da594db68ddde05444afab908b66a9"
 dependencies = [
  "masterror-template",
  "proc-macro2",
@@ -1665,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55940293fa5d7fc9e7defaf45097b5d502f2d9be4083901f5c255258c5a2bfdd"
+checksum = "76cbb19c37caa0e505f0fb43a68184a4d22dc6e81daea40dd00fc24a356ffa9a"
 
 [[package]]
 name = "memchr"
@@ -2747,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.12"
+version = "0.2.13"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"
@@ -16,7 +16,7 @@ rust-version = "1.90"
 
 [workspace.dependencies]
 inventory = "0.3.21"
-masterror = "0.11"
+masterror = "0.24"
 
 
 [lib]


### PR DESCRIPTION
## Summary
- upgrade the workspace `masterror` dependency to 0.24 and refresh the lockfile
- bump the crate version to 0.2.13 and record the change in the changelog

## Testing
- `cargo build --all-targets`
- `cargo test --all`
- `cargo clippy -- -D warnings`
- `cargo doc --no-deps`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68dceccf12e4832bb45c4f328b589511