### PR TITLE
Ensure Rultor installs nightly rustfmt component

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -11,7 +11,9 @@ env:
   CARGO_TERM_COLOR: never
 
 install: |
+  rustup toolchain install nightly
   rustup component add rustfmt clippy
+  rustup component add rustfmt --toolchain nightly
 
 merge:
   script: |


### PR DESCRIPTION
## Summary
- install the nightly toolchain in the Rultor environment
- add the nightly rustfmt component while keeping existing stable components

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd0a8f3a7c832badc3545af2b3af9e