### PR TITLE
Fix release version replacement

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -24,8 +24,7 @@ release:
   pre: false
   script: |
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
-    sed -i -e "s/^version = \"0.0.0\"/version = \"${tag}\"/" Cargo.toml
-    sed -i -e "s/0.0.0/${tag}/" src/lib.rs
+    sed -i -E 's/^(version = ")([0-9]+\.[0-9]+\.[0-9]+)(".*)/\1'${tag}'\3/' Cargo.toml
     cargo test --all-features -vv -- --nocapture
     cargo +nightly fmt --check
     cargo clippy -- --no-deps -D warnings


### PR DESCRIPTION
## Summary
- update the release script to rewrite the Cargo.toml version using a semantic-version-aware sed expression
- remove the unused secondary sed invocation from the release pipeline

## Testing
- tag=0.2.99; [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && sed -i -E 's/^(version = ")([0-9]+\.[0-9]+\.[0-9]+)(".*)/\1'"${tag}"'\3/' Cargo.toml && git commit -am "${tag}" && git reset --hard HEAD~1

------
https://chatgpt.com/codex/tasks/task_e_68dd0aadb834832babeb9b06b4b0af84