### PR TITLE
Fix docs.rs docs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14] - 2025-10-03
+### Fixed
+- Guarded the nightly-only `doc_auto_cfg` attribute behind a compiler channel
+  probe so documentation builds on docs.rs no longer fail on stable toolchains.
+
+### Changed
+- Added a lightweight build-time check using `version_check` to conditionally
+  enable nightly-only documentation features without impacting stable
+  consumers.
+
 ## [0.2.13] - 2025-10-01
 ### Changed
 - Upgraded to `masterror` 0.24 across the workspace, ensuring the SDK and demo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2770,6 +2770,7 @@ dependencies = [
  "serde_urlencoded",
  "toml",
  "urlencoding",
+ "version_check",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.13"
+version = "0.2.14"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"
@@ -56,6 +56,9 @@ reqwest = { version = "0.12", default-features = false, features = [
 urlencoding = { version = "2", optional = true }
 inventory = { workspace = true, optional = true }
 toml = "0.9"
+
+[build-dependencies]
+version_check = "0.9"
 
 [dependencies.yew]
 version = "0.21"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(has_doc_auto_cfg)");
+
+    if version_check::Channel::read().is_some_and(|channel| channel.supports_features()) {
+        println!("cargo:rustc-cfg=has_doc_auto_cfg");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(all(docsrs, has_doc_auto_cfg), feature(doc_auto_cfg))]
 
 pub mod api;
 pub mod core;


### PR DESCRIPTION
## Summary
- gate the nightly-only `doc_auto_cfg` attribute behind a build-script channel probe so docs.rs builds succeed on stable toolchains
- add a build-time `version_check` dependency and release notes for 0.2.14

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.90.0 build --all-targets`
- `cargo +1.90.0 test --all`
- `RUSTDOCFLAGS="--cfg docsrs" cargo +1.90.0 doc --no-deps --all-features`
- `cargo audit`
- `cargo deny check` *(fails: unable to fetch advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68df16fc46e8832b85a831786d9b99f5