### PR TITLE
Fix docs.rs compatibility after doc_auto_cfg removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15] - 2025-10-05
+### Fixed
+- Restored compatibility with the latest nightly toolchains by probing support
+  for `doc_cfg` and `doc_auto_cfg`, ensuring docs.rs builds succeed after the
+  upstream removal of `doc_auto_cfg`.
+
+### Changed
+- Emitted explicit `cargo:rustc-check-cfg` declarations for both documentation
+  capability flags so that future compilers surface helpful diagnostics when
+  the build script conditions fall out of sync.
+
 ## [0.2.14] - 2025-10-03
 ### Fixed
 - Guarded the nightly-only `doc_auto_cfg` attribute behind a compiler channel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.2.14"
+version = "0.2.15"
 rust-version = "1.90"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,12 @@
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(has_doc_cfg)");
     println!("cargo:rustc-check-cfg=cfg(has_doc_auto_cfg)");
 
-    if version_check::Channel::read().is_some_and(|channel| channel.supports_features()) {
+    if version_check::supports_feature("doc_cfg").unwrap_or(false) {
+        println!("cargo:rustc-cfg=has_doc_cfg");
+    }
+
+    if version_check::supports_feature("doc_auto_cfg").unwrap_or(false) {
         println!("cargo:rustc-cfg=has_doc_auto_cfg");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(all(docsrs, has_doc_auto_cfg), feature(doc_auto_cfg))]
+#![cfg_attr(all(docsrs, has_doc_cfg), feature(doc_cfg))]
+#![cfg_attr(all(docsrs, not(has_doc_cfg), has_doc_auto_cfg), feature(doc_auto_cfg))]
 
 pub mod api;
 pub mod core;


### PR DESCRIPTION
## Summary
- detect whether `doc_cfg` or `doc_auto_cfg` is available at build time and only enable the matching rustdoc feature
- declare the corresponding `check-cfg` probes and bump the crate to version 0.2.15 with changelog notes

## Testing
- cargo +nightly fmt --
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(failed to install within time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fd325108832ba5f7a74b9ff93b6f