### PR TITLE
111

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "coverage"
+          shared-key: "stable"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
Closes #111

## Summary
- Unified cargo cache key from `coverage` to `stable` across all CI jobs
- Coverage job now reuses dependencies downloaded by clippy/test jobs

## Benefits
- Faster CI execution (coverage job skips dependency downloads)
- Reduced bandwidth usage
- Simplified cache management

## Changes
- Changed `shared-key: "coverage"` to `shared-key: "stable"` in coverage job

## Testing
CI will validate that all jobs pass with unified cache key.