### PR TITLE
116

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -8,6 +8,32 @@ on:
         default: true
 
 jobs:
+  # 🔧 Setup
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -y && sudo apt-get install -y jq
+          fi
+          RV=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].rust_version // empty')
+          if [ -z "$RV" ]; then
+            echo "rust-version is not set in Cargo.toml"
+            exit 1
+          fi
+          [[ "$RV" =~ ^[0-9]+\.[0-9]+$ ]] && RV="${RV}.0"
+          echo "msrv=${RV}" >> "$GITHUB_OUTPUT"
+          echo "Using MSRV: $RV"
+
   # 📋 Code Quality Checks
   code-quality:
     name: Code Quality
@@ -35,33 +61,17 @@ jobs:
   clippy:
     name: Clippy (MSRV)
     runs-on: ubuntu-latest
+    needs: setup
     env:
       CARGO_LOCKED: "true"
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
 
-      - name: Read MSRV from Cargo.toml
-        id: msrv
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update -y && sudo apt-get install -y jq
-          fi
-          RV=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].rust_version // empty')
-          if [ -z "$RV" ]; then
-            echo "rust-version is not set in Cargo.toml"
-            exit 1
-          fi
-          [[ "$RV" =~ ^[0-9]+\.[0-9]+$ ]] && RV="${RV}.0"
-          echo "msrv=${RV}" >> "$GITHUB_OUTPUT"
-          echo "Using MSRV: $RV"
-
-      - name: Install Rust (${{ steps.msrv.outputs.msrv }})
+      - name: Install Rust (${{ needs.setup.outputs.msrv }})
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+          toolchain: ${{ needs.setup.outputs.msrv }}
           components: clippy
 
       - name: Cache cargo
@@ -75,42 +85,26 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ inputs.all-features }}" = "true" ]; then
-            cargo +${{ steps.msrv.outputs.msrv }} clippy --workspace --all-targets --all-features -- -D warnings
+            cargo +${{ needs.setup.outputs.msrv }} clippy --workspace --all-targets --all-features -- -D warnings
           else
-            cargo +${{ steps.msrv.outputs.msrv }} clippy --workspace --all-targets -- -D warnings
+            cargo +${{ needs.setup.outputs.msrv }} clippy --workspace --all-targets -- -D warnings
           fi
 
   # 🧪 Tests
   test:
     name: Tests (MSRV)
     runs-on: ubuntu-latest
+    needs: setup
     env:
       CARGO_LOCKED: "true"
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
 
-      - name: Read MSRV from Cargo.toml
-        id: msrv
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update -y && sudo apt-get install -y jq
-          fi
-          RV=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].rust_version // empty')
-          if [ -z "$RV" ]; then
-            echo "rust-version is not set in Cargo.toml"
-            exit 1
-          fi
-          [[ "$RV" =~ ^[0-9]+\.[0-9]+$ ]] && RV="${RV}.0"
-          echo "msrv=${RV}" >> "$GITHUB_OUTPUT"
-          echo "Using MSRV: $RV"
-
-      - name: Install Rust (${{ steps.msrv.outputs.msrv }})
+      - name: Install Rust (${{ needs.setup.outputs.msrv }})
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+          toolchain: ${{ needs.setup.outputs.msrv }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -137,9 +131,9 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ inputs.all-features }}" = "true" ]; then
-            cargo +${{ steps.msrv.outputs.msrv }} nextest run --workspace --all-features --no-fail-fast --profile ci
+            cargo +${{ needs.setup.outputs.msrv }} nextest run --workspace --all-features --no-fail-fast --profile ci
           else
-            cargo +${{ steps.msrv.outputs.msrv }} nextest run --workspace --no-fail-fast --profile ci
+            cargo +${{ needs.setup.outputs.msrv }} nextest run --workspace --no-fail-fast --profile ci
           fi
 
       - name: Upload test results to Codecov
@@ -152,34 +146,17 @@ jobs:
   build:
     name: Build & Package
     runs-on: ubuntu-latest
-    needs: [code-quality, clippy, test]
+    needs: [setup, code-quality, clippy, test]
     env:
       CARGO_LOCKED: "true"
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
 
-      - name: Read MSRV from Cargo.toml
-        id: msrv
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update -y && sudo apt-get install -y jq
-          fi
-          RV=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].rust_version // empty')
-          if [ -z "$RV" ]; then
-            echo "rust-version is not set in Cargo.toml"
-            exit 1
-          fi
-          [[ "$RV" =~ ^[0-9]+\.[0-9]+$ ]] && RV="${RV}.0"
-          echo "msrv=${RV}" >> "$GITHUB_OUTPUT"
-          echo "Using MSRV: $RV"
-
-      - name: Install Rust (${{ steps.msrv.outputs.msrv }})
+      - name: Install Rust (${{ needs.setup.outputs.msrv }})
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+          toolchain: ${{ needs.setup.outputs.msrv }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -207,36 +184,20 @@ jobs:
           fi
 
       - name: Package (dry-run)
-        run: cargo +${{ steps.msrv.outputs.msrv }} package --locked
+        run: cargo +${{ needs.setup.outputs.msrv }} package --locked
 
   # 📊 Coverage
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    needs: setup
     steps:
       - uses: actions/checkout@v5
 
-      - name: Read MSRV from Cargo.toml
-        id: msrv
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update -y && sudo apt-get install -y jq
-          fi
-          RV=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].rust_version // empty')
-          if [ -z "$RV" ]; then
-            echo "rust-version is not set in Cargo.toml"
-            exit 1
-          fi
-          [[ "$RV" =~ ^[0-9]+\.[0-9]+$ ]] && RV="${RV}.0"
-          echo "msrv=${RV}" >> "$GITHUB_OUTPUT"
-          echo "Using MSRV: $RV"
-
-      - name: Install Rust (${{ steps.msrv.outputs.msrv }})
+      - name: Install Rust (${{ needs.setup.outputs.msrv }})
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+          toolchain: ${{ needs.setup.outputs.msrv }}
           components: llvm-tools-preview
 
       - name: Cache cargo
@@ -254,7 +215,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo +${{ steps.msrv.outputs.msrv }} llvm-cov --all-features --workspace --lcov --output-path lcov.info
+          cargo +${{ needs.setup.outputs.msrv }} llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Closes #116

## Summary
Extracted MSRV reading into separate setup job. Other jobs now receive MSRV via `needs.setup.outputs.msrv`.

## Changes
- Added setup job that reads MSRV and exports as output
- Updated clippy, test, build, coverage jobs to use `needs: setup`
- Replaced all `steps.msrv.outputs.msrv` with `needs.setup.outputs.msrv`
- Removed 4 duplicate MSRV reading blocks

## Impact
- Reduced code duplication (83 lines removed)
- Single source of truth for MSRV
- Easier maintenance
- Faster CI (jq installation happens once)