### PR TITLE
127

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@
 
 `telegram-webapp-sdk` provides a type-safe and ergonomic wrapper around the [Telegram Web Apps](https://core.telegram.org/bots/webapps) JavaScript API.
 
+> **⚠️ WARNING: Coverage Limitations**
+>
+> This project is primarily WASM-only code. Current Rust tooling does not support coverage measurement for wasm32 targets:
+> - `cargo-llvm-cov` only supports native platforms (x86_64)
+> - `wasm-bindgen-test` coverage support is experimental and requires complex setup
+> - `cargo-tarpaulin` does not support wasm32
+>
+> Coverage reports show only native-testable code. WASM-specific modules (leptos, yew, api/*, webapp, logger) have integration tests but are not included in coverage metrics.
+>
+> For technical details, see [issue #127](https://github.com/RAprogramm/telegram-webapp-sdk/issues/127).
+
 <details>
 <summary>Coverage Graphs</summary>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,15 @@ ignore:
   - "tests/**/*"
   - "target/**/*"
   - ".github/**/*"
+  - "src/leptos.rs"
+  - "src/leptos/**/*"
+  - "src/yew.rs"
+  - "src/yew/**/*"
+  - "src/api/**/*"
+  - "src/webapp.rs"
+  - "src/logger.rs"
+  - "src/pages.rs"
+  - "src/router.rs"
 
 github_checks:
   annotations: true


### PR DESCRIPTION
Closes #127

## Summary
Added comprehensive documentation about WASM coverage limitations and updated codecov configuration to exclude WASM-only files.

## Changes
- Added WARNING section in README explaining coverage constraints
- Updated codecov.yml to ignore WASM-only modules (leptos, yew, api/*, webapp, logger, pages, router)
- Fixed lifetime issue in tests/init_sdk.rs
- Closed issues #118-#124 as not applicable (WASM-only)
- Created issue #128 documenting full investigation and future strategy

## Coverage Strategy
Current Rust tooling cannot measure coverage for wasm32 targets:
- cargo-llvm-cov: native only
- wasm-bindgen-test coverage: experimental
- cargo-tarpaulin: no wasm32 support

WASM code quality ensured through:
- Integration tests with wasm-bindgen-test
- Type safety
- Manual browser testing

## References
- Issue #127: Technical investigation
- Issue #128: Complete strategy documentation
- README WARNING section
- Updated codecov.yml configuration