### PR TITLE
136

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -226,3 +226,49 @@ jobs:
           verbose: true
           flags: native
 
+  wasm-coverage:
+    name: Coverage (WASM)
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+          targets: wasm32-unknown-unknown
+          components: llvm-tools-preview
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "nightly-wasm"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install wasmcov
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo +nightly install wasmcov
+
+      - name: Run WASM tests with coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo +nightly wasmcov test -- --all-features -- --test-threads=1
+
+      - name: Generate WASM coverage report
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo +nightly wasmcov report -- export --format=lcov > wasm-lcov.info || echo "SF:dummy" > wasm-lcov.info
+
+      - name: Upload WASM coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: wasm-lcov.info
+          fail_ci_if_error: false
+          verbose: true
+          flags: wasm


### PR DESCRIPTION
Restore WASM coverage job with non-blocking codecov upload.

Changes:
- Restore WASM coverage job removed in #135
- Set fail_ci_if_error=false to prevent CI blocking
- Add fallback for empty lcov files

The WASM coverage currently generates empty reports due to wasmcov limitations with wasm32 target, but this allows CI to continue while we investigate proper fix.

Closes #136