### PR TITLE
#145 feat: improve initialization API with environment detection and typed errors

### DIFF
--- a/src/core/init.rs
+++ b/src/core/init.rs
@@ -15,27 +15,124 @@ use crate::core::{
     }
 };
 
-/// Initializes Telegram WebApp SDK by extracting and validating context.
+/// Typed initialization errors for better error handling and debugging.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InitError {
+    /// Browser `window` object is not available
+    WindowUnavailable,
+    /// `window.Telegram` is undefined
+    TelegramUnavailable,
+    /// `Telegram.WebApp` is undefined
+    WebAppUnavailable,
+    /// Failed to parse `WebApp.initData`
+    InitDataParseFailed(String),
+    /// Failed to parse theme parameters
+    ThemeParamsParseFailed(String),
+    /// Failed to initialize global context
+    ContextInitFailed(String)
+}
+
+impl std::fmt::Display for InitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WindowUnavailable => write!(f, "Browser window object is not available"),
+            Self::TelegramUnavailable => write!(f, "window.Telegram is undefined"),
+            Self::WebAppUnavailable => write!(f, "Telegram.WebApp is undefined"),
+            Self::InitDataParseFailed(msg) => write!(f, "Failed to parse initData: {msg}"),
+            Self::ThemeParamsParseFailed(msg) => {
+                write!(f, "Failed to parse theme parameters: {msg}")
+            }
+            Self::ContextInitFailed(msg) => write!(f, "Failed to initialize context: {msg}")
+        }
+    }
+}
+
+impl std::error::Error for InitError {}
+
+impl From<InitError> for JsValue {
+    fn from(err: InitError) -> Self {
+        JsValue::from_str(&err.to_string())
+    }
+}
+
+/// Check if Telegram WebApp environment is available.
 ///
-/// - Parses `initData` (urlencoded) with embedded JSON.
-/// - Parses `themeParams` (object).
-/// - Initializes global context.
+/// Returns `true` if `window.Telegram.WebApp` exists and is defined.
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::core::init::is_telegram_available;
+///
+/// if is_telegram_available() {
+///     println!("Running inside Telegram Mini App");
+/// } else {
+///     println!("Running in regular browser");
+/// }
+/// ```
+pub fn is_telegram_available() -> bool {
+    window()
+        .and_then(|w| Reflect::get(&w, &"Telegram".into()).ok())
+        .filter(|tg| !tg.is_undefined())
+        .and_then(|tg| Reflect::get(&tg, &"WebApp".into()).ok())
+        .filter(|webapp| !webapp.is_undefined())
+        .is_some()
+}
+
+/// Attempt to initialize SDK without panicking if Telegram environment is
+/// unavailable.
+///
+/// Returns:
+/// - `Ok(true)` if SDK was successfully initialized
+/// - `Ok(false)` if Telegram environment is not available (graceful
+///   degradation)
+/// - `Err(InitError)` for actual initialization failures
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::core::init::try_init_sdk;
+///
+/// match try_init_sdk() {
+///     Ok(true) => println!("SDK initialized successfully"),
+///     Ok(false) => println!("Not running in Telegram, using fallback"),
+///     Err(e) => eprintln!("Initialization error: {}", e)
+/// }
+/// ```
 ///
 /// # Errors
-/// Returns `Err(JsValue)` on failure to access JS globals, parse, or init
-/// context.
-pub fn init_sdk() -> Result<(), JsValue> {
-    let win = window().ok_or_else(|| JsValue::from_str("window is not available"))?;
-    let telegram = Reflect::get(&win, &"Telegram".into())?;
-    let webapp = Reflect::get(&telegram, &"WebApp".into())?;
+/// Returns typed `InitError` for parsing failures or context initialization
+/// issues.
+pub fn try_init_sdk() -> Result<bool, InitError> {
+    if !is_telegram_available() {
+        return Ok(false);
+    }
+    init_sdk_typed().map(|_| true)
+}
+
+/// Internal typed version of init_sdk for use by try_init_sdk.
+fn init_sdk_typed() -> Result<(), InitError> {
+    let win = window().ok_or(InitError::WindowUnavailable)?;
+    let telegram =
+        Reflect::get(&win, &"Telegram".into()).map_err(|_| InitError::TelegramUnavailable)?;
+
+    if telegram.is_undefined() {
+        return Err(InitError::TelegramUnavailable);
+    }
+
+    let webapp =
+        Reflect::get(&telegram, &"WebApp".into()).map_err(|_| InitError::WebAppUnavailable)?;
+
+    if webapp.is_undefined() {
+        return Err(InitError::WebAppUnavailable);
+    }
 
     // === 1. Parse initData string ===
-    let init_data_str = Reflect::get(&webapp, &"initData".into())?
-        .as_string()
-        .ok_or_else(|| JsValue::from_str("Telegram.WebApp.initData is not a string"))?;
+    let init_data_str = Reflect::get(&webapp, &"initData".into())
+        .ok()
+        .and_then(|v| v.as_string())
+        .ok_or_else(|| InitError::InitDataParseFailed("initData is not a string".to_string()))?;
 
     let raw: TelegramInitDataInternal = serde_urlencoded::from_str(&init_data_str)
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse initData: {e}")))?;
+        .map_err(|e| InitError::InitDataParseFailed(e.to_string()))?;
 
     // === 2. Parse embedded JSON fields ===
     let user: Option<TelegramUser> = raw
@@ -43,21 +140,21 @@ pub fn init_sdk() -> Result<(), JsValue> {
         .as_deref()
         .map(serde_json::from_str)
         .transpose()
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse user: {e}")))?;
+        .map_err(|e| InitError::InitDataParseFailed(format!("Failed to parse user: {e}")))?;
 
     let receiver: Option<TelegramUser> = raw
         .receiver
         .as_deref()
         .map(serde_json::from_str)
         .transpose()
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse receiver: {e}")))?;
+        .map_err(|e| InitError::InitDataParseFailed(format!("Failed to parse receiver: {e}")))?;
 
     let chat: Option<TelegramChat> = raw
         .chat
         .as_deref()
         .map(serde_json::from_str)
         .transpose()
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse chat: {e}")))?;
+        .map_err(|e| InitError::InitDataParseFailed(format!("Failed to parse chat: {e}")))?;
 
     // === 3. Construct final typed initData ===
     let init_data = TelegramInitData {
@@ -75,13 +172,47 @@ pub fn init_sdk() -> Result<(), JsValue> {
     };
 
     // === 4. Parse themeParams ===
-    let theme_val = Reflect::get(&webapp, &"themeParams".into())?;
-    let theme_params: TelegramThemeParams = from_value(theme_val)?;
-
-    // theme_params.clone().apply_to_root();
+    let theme_val = Reflect::get(&webapp, &"themeParams".into())
+        .map_err(|e| InitError::ThemeParamsParseFailed(format!("{e:?}")))?;
+    let theme_params: TelegramThemeParams =
+        from_value(theme_val).map_err(|e| InitError::ThemeParamsParseFailed(format!("{e:?}")))?;
 
     // === 5. Init global context ===
-    TelegramContext::init(init_data, theme_params, init_data_str)?;
+    TelegramContext::init(init_data, theme_params, init_data_str)
+        .map_err(|e| InitError::ContextInitFailed(format!("{e:?}")))?;
 
     Ok(())
+}
+
+/// Initializes Telegram WebApp SDK by extracting and validating context.
+///
+/// - Parses `initData` (urlencoded) with embedded JSON.
+/// - Parses `themeParams` (object).
+/// - Initializes global context.
+///
+/// # Errors
+///
+/// Returns `Err(JsValue)` in the following cases:
+///
+/// - `WindowUnavailable`: No browser `window` object found
+/// - `TelegramUnavailable`: `window.Telegram` is undefined
+/// - `WebAppUnavailable`: `Telegram.WebApp` is undefined
+/// - `InitDataParseFailed`: Failed to parse `WebApp.initData`
+/// - `ThemeParamsParseFailed`: Failed to parse theme parameters
+/// - `ContextInitFailed`: Failed to initialize global context
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::core::init::init_sdk;
+///
+/// match init_sdk() {
+///     Ok(_) => println!("SDK initialized successfully"),
+///     Err(e) => eprintln!("Initialization failed: {:?}", e)
+/// }
+/// ```
+///
+/// For better error handling, consider using [`try_init_sdk`] which returns
+/// typed [`InitError`].
+pub fn init_sdk() -> Result<(), JsValue> {
+    init_sdk_typed().map_err(Into::into)
 }


### PR DESCRIPTION
## Summary

Improves the initialization API by adding environment detection and typed error handling, addressing the issues outlined in #145.

## Changes

### 1. Added `InitError` enum for typed error handling

Replaced opaque `JsValue` errors with a structured enum that clearly identifies:
- `WindowUnavailable` - No browser window object
- `TelegramUnavailable` - window.Telegram is undefined
- `WebAppUnavailable` - Telegram.WebApp is undefined  
- `InitDataParseFailed(String)` - Failed to parse initData
- `ThemeParamsParseFailed(String)` - Failed to parse theme parameters
- `ContextInitFailed(String)` - Failed to initialize context

### 2. Implemented `is_telegram_available()` function

New public function to check if Telegram WebApp environment is available without attempting full initialization:

```rust
if is_telegram_available() {
    println!("Running inside Telegram Mini App");
} else {
    println!("Running in regular browser");
}
```

### 3. Added `try_init_sdk()` for graceful initialization

Returns `Result<bool, InitError>` where:
- `Ok(true)` - SDK successfully initialized
- `Ok(false)` - Telegram environment unavailable (graceful degradation)
- `Err(InitError)` - Actual initialization failure

```rust
match try_init_sdk() {
    Ok(true) => println!("SDK initialized successfully"),
    Ok(false) => println!("Not running in Telegram, using fallback"),
    Err(e) => eprintln!("Initialization error: {}", e),
}
```

### 4. Updated `init_sdk()` to use typed errors internally

Maintains backward compatibility with `Result<(), JsValue>` signature while using typed errors internally. Documentation now includes detailed error descriptions.

### 5. Comprehensive test coverage

Added 7 new tests covering:
- Environment detection (available/unavailable scenarios)
- Graceful initialization (success/fallback scenarios)
- Error type formatting and conversion to JsValue

## Benefits

- Reduces boilerplate in consuming applications
- Improves error handling and debugging
- Enables graceful degradation patterns
- Makes API more ergonomic and discoverable
- Better aligns with Rust error handling best practices

## Migration

All changes are backward compatible. Existing code using `init_sdk()` continues to work unchanged.

Closes #145

**Full Changelog**: https://github.com/RAprogramm/telegram-webapp-sdk/compare/main...145