### PR TITLE
185

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![CI](https://github.com/RAprogramm/telegram-webapp-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/RAprogramm/telegram-webapp-sdk/actions/workflows/ci.yml)
 [![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/telegram-webapp-sdk)](https://api.reuse.software/info/github.com/RAprogramm/telegram-webapp-sdk)
 <!-- webapp_api_badges:start -->
-[![Telegram WebApp API](https://img.shields.io/badge/Telegram%20WebApp%20API-9.5-blue)](https://core.telegram.org/bots/webapps)
+[![Telegram WebApp API](https://img.shields.io/badge/Telegram%20WebApp%20API-9.6-blue)](https://core.telegram.org/bots/webapps)
 [![Coverage](https://img.shields.io/badge/Coverage-up%20to%20date%20%2892abbf7%29-brightgreen)](https://github.com/RAprogramm/telegram-webapp-sdk/commit/92abbf7)
 <!-- webapp_api_badges:end -->
 [![Wiki](https://img.shields.io/badge/Wiki-Documentation-0088cc?logo=github)](https://github.com/RAprogramm/telegram-webapp-sdk/wiki)
@@ -103,7 +103,7 @@ The top section represents the entire project. Proceeding with folders and final
 - Optional macros for automatic initialization and routing.
 - DOM helpers for ergonomic element manipulation.
 - Biometric authentication helpers, viewport metrics, and theme utilities in
-  step with the Telegram WebApp API 9.2 feature set.
+  step with the Telegram WebApp API 9.6 feature set.
   
 <p align="right"><a href="#readme-top">Back to top</a></p>
 
@@ -346,17 +346,18 @@ let ctx = telegram_webapp_sdk::mock::install(config)?;
 Request access to sensitive user data or open the contact interface:
 
 ```rust,no_run
-use telegram_webapp_sdk::api::user::{request_contact, request_phone_number, open_contact};
+use telegram_webapp_sdk::api::user::request_contact;
 use telegram_webapp_sdk::webapp::TelegramWebApp;
 
 # fn run() -> Result<(), wasm_bindgen::JsValue> {
 request_contact()?;
-request_phone_number()?;
-open_contact()?;
 
 let app = TelegramWebApp::try_instance()?;
 app.request_write_access(|granted| {
     let _ = granted;
+})?;
+app.request_chat(42, |sent| {
+    let _ = sent;
 })?;
 # Ok(())
 # }
@@ -459,7 +460,6 @@ use telegram_webapp_sdk::webapp::TelegramWebApp;
 # fn run() -> Result<(), wasm_bindgen::JsValue> {
 let app = TelegramWebApp::try_instance()?;
 app.share_url("https://example.com", Some("Check this out"))?;
-app.join_voice_chat("chat", None)?;
 app.share_message("msg-id", |sent| {
     let _ = sent;
 })?;
@@ -568,11 +568,12 @@ Supported background events:
 | `settingsButtonClicked` | none |
 | `writeAccessRequested` | `bool` granted flag |
 | `contactRequested` | `bool` shared flag |
-| `phoneRequested` | `bool` shared flag |
 | `invoiceClosed` | status `String` |
 | `popupClosed` | object `{ button_id: Option<String> }` |
 | `qrTextReceived` | scanned text `String` |
 | `clipboardTextReceived` | clipboard text `String` |
+| `requestedChatSent` | none (Bot API 9.6) |
+| `requestedChatFailed` | object `{ error: String }` (Bot API 9.6) |
 
 <p align="right"><a href="#readme-top">Back to top</a></p>
 

--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -2,12 +2,12 @@
 
 <!--
 [webapp_api_status]
-latest_version = "9.2"
-covered_version = "9.2"
-coverage_commit = "92abbf7"
-coverage_date = "2025-09-21"
+latest_version = "9.6"
+covered_version = "9.6"
+coverage_commit = "HEAD"
+coverage_date = "2026-05-13"
 source_url = "https://core.telegram.org/bots/webapps"
-latest_version_probe_url = "https://raw.githubusercontent.com/tdlib/telegram-bot-api/master/telegram-bot-api/telegram-bot-api.cpp"
+latest_version_probe_url = "https://telegram.org/js/telegram-web-app.js"
 -->
 
 This checklist tracks support for the [Telegram Web Apps JavaScript API](https://core.telegram.org/bots/webapps). Mark items as they are implemented.
@@ -30,11 +30,9 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] shareURL ([a098e00](https://github.com/RAprogramm/telegram-webapp-sdk/commit/a098e00))
 - [x] shareMessage ([4b10c98](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4b10c98))
 - [x] shareToStory ([4b10c98](https://github.com/RAprogramm/telegram-webapp-sdk/commit/4b10c98))
-- [x] joinVoiceChat ([a098e00](https://github.com/RAprogramm/telegram-webapp-sdk/commit/a098e00))
 - [x] requestWriteAccess ([a098e00](https://github.com/RAprogramm/telegram-webapp-sdk/commit/a098e00))
 - [x] requestContact ([d595540](https://github.com/RAprogramm/telegram-webapp-sdk/commit/d595540))
-- [x] requestPhoneNumber ([d595540](https://github.com/RAprogramm/telegram-webapp-sdk/commit/d595540))
-- [x] openContact ([d595540](https://github.com/RAprogramm/telegram-webapp-sdk/commit/d595540))
+- [x] requestChat (Bot API 9.6)
 - [x] enableVerticalSwipes ([8e60df3](https://github.com/RAprogramm/telegram-webapp-sdk/commit/8e60df3))
 - [x] disableVerticalSwipes ([8e60df3](https://github.com/RAprogramm/telegram-webapp-sdk/commit/8e60df3))
 - [x] hideKeyboard ([94ff585](https://github.com/RAprogramm/telegram-webapp-sdk/commit/94ff585))
@@ -75,6 +73,7 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] isActive ([92abbf7](https://github.com/RAprogramm/telegram-webapp-sdk/commit/92abbf7))
 - [x] isProgressVisible ([92abbf7](https://github.com/RAprogramm/telegram-webapp-sdk/commit/92abbf7))
 - [x] hasShineEffect ([92abbf7](https://github.com/RAprogramm/telegram-webapp-sdk/commit/92abbf7))
+- [x] iconCustomEmojiId (Bot API 9.5)
 
 ### MainButton
 - [x] show ([bcce132](https://github.com/RAprogramm/telegram-webapp-sdk/commit/bcce132))
@@ -192,13 +191,14 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 | `settingsButtonClicked` | none |
 | `writeAccessRequested` | `bool` granted flag |
 | `contactRequested` | `bool` shared flag |
-| `phoneRequested` | `bool` shared flag |
 | `invoiceClosed` | status `String` |
 | `popupClosed` | object `{ button_id: Option<String> }` |
 | `qrTextReceived` | scanned text `String` |
 | `clipboardTextReceived` | clipboard text `String` |
+| `requestedChatSent` | none (Bot API 9.6) |
+| `requestedChatFailed` | object `{ error: String }` (Bot API 9.6) |
 
 ## Remaining WebApp Features
 
-The SDK currently covers the complete Telegram WebApp API 9.2 surface. If you
+The SDK currently covers the complete Telegram WebApp API 9.6 surface. If you
 spot a gap, please open an issue so it can be addressed quickly.

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use js_sys::{Function, Reflect};
@@ -23,49 +23,6 @@ pub fn request_contact() -> Result<(), JsValue> {
     let webapp = webapp_object()?;
     let func =
         Reflect::get(&webapp, &JsValue::from_str("requestContact"))?.dyn_into::<Function>()?;
-    func.call0(&webapp)?;
-    Ok(())
-}
-
-/// Calls `Telegram.WebApp.requestPhoneNumber()`.
-///
-/// Requires the user's explicit permission to share their phone number.
-///
-/// # Errors
-/// Returns `Err(JsValue)` if `Telegram.WebApp` or the method is unavailable, or
-/// if the call fails.
-///
-/// # Examples
-/// ```no_run
-/// use telegram_webapp_sdk::api::user::request_phone_number;
-///
-/// let _ = request_phone_number();
-/// ```
-pub fn request_phone_number() -> Result<(), JsValue> {
-    let webapp = webapp_object()?;
-    let func =
-        Reflect::get(&webapp, &JsValue::from_str("requestPhoneNumber"))?.dyn_into::<Function>()?;
-    func.call0(&webapp)?;
-    Ok(())
-}
-
-/// Calls `Telegram.WebApp.openContact()`.
-///
-/// Requires the user's permission to open the contact interface in Telegram.
-///
-/// # Errors
-/// Returns `Err(JsValue)` if `Telegram.WebApp` or the method is unavailable, or
-/// if the call fails.
-///
-/// # Examples
-/// ```no_run
-/// use telegram_webapp_sdk::api::user::open_contact;
-///
-/// let _ = open_contact();
-/// ```
-pub fn open_contact() -> Result<(), JsValue> {
-    let webapp = webapp_object()?;
-    let func = Reflect::get(&webapp, &JsValue::from_str("openContact"))?.dyn_into::<Function>()?;
     func.call0(&webapp)?;
     Ok(())
 }
@@ -116,49 +73,5 @@ mod tests {
     fn request_contact_err() {
         let _ = setup_webapp();
         assert!(request_contact().is_err());
-    }
-
-    #[wasm_bindgen_test]
-    #[allow(dead_code, clippy::unused_unit)]
-    fn request_phone_number_ok() {
-        let webapp = setup_webapp();
-        let func = Function::new_no_args("this.called = true;");
-        let _ = Reflect::set(&webapp, &"requestPhoneNumber".into(), &func);
-        assert!(request_phone_number().is_ok());
-        assert!(
-            Reflect::get(&webapp, &"called".into())
-                .unwrap()
-                .as_bool()
-                .unwrap()
-        );
-    }
-
-    #[wasm_bindgen_test]
-    #[allow(dead_code, clippy::unused_unit)]
-    fn request_phone_number_err() {
-        let _ = setup_webapp();
-        assert!(request_phone_number().is_err());
-    }
-
-    #[wasm_bindgen_test]
-    #[allow(dead_code, clippy::unused_unit)]
-    fn open_contact_ok() {
-        let webapp = setup_webapp();
-        let func = Function::new_no_args("this.called = true;");
-        let _ = Reflect::set(&webapp, &"openContact".into(), &func);
-        assert!(open_contact().is_ok());
-        assert!(
-            Reflect::get(&webapp, &"called".into())
-                .unwrap()
-                .as_bool()
-                .unwrap()
-        );
-    }
-
-    #[wasm_bindgen_test]
-    #[allow(dead_code, clippy::unused_unit)]
-    fn open_contact_err() {
-        let _ = setup_webapp();
-        assert!(open_contact().is_err());
     }
 }

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -1134,31 +1134,24 @@ mod tests {
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
-    fn join_voice_chat_calls_js() {
+    fn request_chat_calls_js() {
         let webapp = setup_webapp();
-        let join = Function::new_with_args(
-            "id, hash",
-            "this.voice_chat_id = id; this.voice_chat_hash = hash;"
-        );
-        let _ = Reflect::set(&webapp, &"joinVoiceChat".into(), &join);
+        let request =
+            Function::new_with_args("req_id, cb", "this.req_chat_id = req_id; cb(true);");
+        let _ = Reflect::set(&webapp, &"requestChat".into(), &request);
 
         let app = TelegramWebApp::instance().unwrap();
-        app.join_voice_chat("123", Some("hash")).unwrap();
+        let sent = std::rc::Rc::new(std::cell::Cell::new(false));
+        let sent_ref = sent.clone();
+        app.request_chat(42, move |s| sent_ref.set(s)).unwrap();
 
         assert_eq!(
-            Reflect::get(&webapp, &"voice_chat_id".into())
+            Reflect::get(&webapp, &"req_chat_id".into())
                 .unwrap()
-                .as_string()
-                .as_deref(),
-            Some("123"),
+                .as_f64(),
+            Some(42.0),
         );
-        assert_eq!(
-            Reflect::get(&webapp, &"voice_chat_hash".into())
-                .unwrap()
-                .as_string()
-                .as_deref(),
-            Some("hash"),
-        );
+        assert!(sent.get());
     }
 
     #[wasm_bindgen_test]

--- a/src/webapp/navigation.rs
+++ b/src/webapp/navigation.rs
@@ -159,30 +159,40 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.joinVoiceChat(chat_id, invite_hash)`.
+    /// Call `WebApp.requestChat(req_id, callback)` (Bot API 9.6+).
+    ///
+    /// Opens a dialog that lets the user pick an existing chat matching the
+    /// prepared keyboard request previously saved via
+    /// `savePreparedKeyboardButton`. The callback receives `true` on
+    /// success and `false` when the user cancels or Telegram reports a
+    /// failure (`requestedChatFailed`).
     ///
     /// # Examples
     /// ```no_run
     /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
     /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.join_voice_chat("chat", None).unwrap();
+    /// app.request_chat(42, |sent| {
+    ///     let _ = sent;
+    /// })
+    /// .unwrap();
     /// ```
     ///
     /// # Errors
-    /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn join_voice_chat(
-        &self,
-        chat_id: &str,
-        invite_hash: Option<&str>
-    ) -> Result<(), JsValue> {
-        let f = Reflect::get(&self.inner, &"joinVoiceChat".into())?;
+    /// Returns [`JsValue`] if the underlying JS call fails (including when the
+    /// running Telegram client predates Bot API 9.6).
+    pub fn request_chat<F>(&self, req_id: i32, callback: F) -> Result<(), JsValue>
+    where
+        F: 'static + Fn(bool)
+    {
+        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+            callback(v.as_bool().unwrap_or(false));
+        });
+        let f = Reflect::get(&self.inner, &"requestChat".into())?;
         let func = f
             .dyn_ref::<Function>()
-            .ok_or_else(|| JsValue::from_str("joinVoiceChat is not a function"))?;
-        match invite_hash {
-            Some(hash) => func.call2(&self.inner, &chat_id.into(), &hash.into())?,
-            None => func.call1(&self.inner, &chat_id.into())?
-        };
+            .ok_or_else(|| JsValue::from_str("requestChat is not a function"))?;
+        func.call2(&self.inner, &req_id.into(), cb.as_ref().unchecked_ref())?;
+        cb.forget();
         Ok(())
     }
 

--- a/src/webapp/types.rs
+++ b/src/webapp/types.rs
@@ -329,8 +329,6 @@ pub enum BackgroundEvent {
     WriteAccessRequested,
     /// User responded to a contact request. Payload: `bool`.
     ContactRequested,
-    /// User responded to a phone number request. Payload: `bool`.
-    PhoneRequested,
     /// An invoice was closed. Payload: status string.
     InvoiceClosed,
     /// A popup was closed. Payload: object containing `button_id`.
@@ -338,7 +336,13 @@ pub enum BackgroundEvent {
     /// Text was received from the QR scanner. Payload: scanned text.
     QrTextReceived,
     /// Text was read from the clipboard. Payload: clipboard text.
-    ClipboardTextReceived
+    ClipboardTextReceived,
+    /// User picked a chat in response to `WebApp.requestChat`
+    /// (Bot API 9.6+). Payload: `JsValue::UNDEFINED`.
+    RequestedChatSent,
+    /// `WebApp.requestChat` failed (user cancelled or Telegram error).
+    /// Payload: object containing `error: String`.
+    RequestedChatFailed
 }
 
 impl BackgroundEvent {
@@ -349,11 +353,12 @@ impl BackgroundEvent {
             BackgroundEvent::SettingsButtonClicked => "settingsButtonClicked",
             BackgroundEvent::WriteAccessRequested => "writeAccessRequested",
             BackgroundEvent::ContactRequested => "contactRequested",
-            BackgroundEvent::PhoneRequested => "phoneRequested",
             BackgroundEvent::InvoiceClosed => "invoiceClosed",
             BackgroundEvent::PopupClosed => "popupClosed",
             BackgroundEvent::QrTextReceived => "qrTextReceived",
-            BackgroundEvent::ClipboardTextReceived => "clipboardTextReceived"
+            BackgroundEvent::ClipboardTextReceived => "clipboardTextReceived",
+            BackgroundEvent::RequestedChatSent => "requestedChatSent",
+            BackgroundEvent::RequestedChatFailed => "requestedChatFailed"
         }
     }
 }


### PR DESCRIPTION
## Summary

Sync the crate with the current Telegram WebApp JavaScript surface (Bot API 9.6, April 2026).

**Breaking changes — removing methods that never existed in `Telegram.WebApp`:**
- `api::user::request_phone_number` (was calling non-existent `WebApp.requestPhoneNumber`)
- `api::user::open_contact` (was calling non-existent `WebApp.openContact`)
- `webapp::TelegramWebApp::join_voice_chat` (was calling non-existent `WebApp.joinVoiceChat`)
- `webapp::types::BackgroundEvent::PhoneRequested` (Telegram never emits `phoneRequested`)

**New (Bot API 9.6):**
- `webapp::TelegramWebApp::request_chat(req_id: i32, callback)` → `WebApp.requestChat(req_id, callback)`.
- `BackgroundEvent::RequestedChatSent` / `RequestedChatFailed`.

**Docs:**
- `WEBAPP_API.md`: bump `covered_version` to 9.6, add `iconCustomEmojiId` (9.5) and `requestChat` (9.6), drop entries for the removed phantom methods, update event table.
- `README.md`: bump WebApp API badge to 9.6, prune phantom-method examples, document `request_chat`, add new background events to the table.

Verified against the upstream `https://telegram.org/js/telegram-web-app.js` (3392 lines) and `https://core.telegram.org/bots/webapps`.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (140/140)
- [ ] CI green