### PR TITLE
190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-13
+### Added
+- `dom` module with `Document` and `ElementExt` ergonomic helpers for vanilla WASM users (#184).
+- `full` feature aggregating `macros`, `yew`, `leptos`, `mock` (#184).
+- `TelegramWebApp::request_chat(req_id, callback)` and `BackgroundEvent::RequestedChatSent` / `RequestedChatFailed` events — Bot API 9.6 (#185).
+- `examples/vanilla` (Trunk-based pure-WASM mini-app) and `examples/integration` (teloxide backend + standalone WASM frontend) (#184).
+
+### Removed
+- **BREAKING:** `api::user::request_phone_number` — no such method in `Telegram.WebApp` (#185).
+- **BREAKING:** `api::user::open_contact` — no such method in `Telegram.WebApp` (#185).
+- **BREAKING:** `TelegramWebApp::join_voice_chat` — no such method in `Telegram.WebApp` (#185).
+- **BREAKING:** `BackgroundEvent::PhoneRequested` — Telegram never emits `phoneRequested`; use `BackgroundEvent::ContactRequested` (#185).
+- Dead `src/dom/event.rs::EventHandler` and empty feature flags in `examples/integration/frontend` (#188).
+
+### Changed
+- `web-sys` features now include `Node`, `EventTarget`, `MouseEvent` for the `dom` module (#184).
+- Workspace members extended with `examples/vanilla`, `examples/bots/rust_bot`, `examples/integration/backend` (#184).
+- README WebApp API badge bumped to 9.6 (#185).
+- `WEBAPP_API.md` now tracks `iconCustomEmojiId` (9.5) and `requestChat` (9.6); `covered_version` bumped to 9.6 (#185).
+
+### Migration Guide
+- Replace `request_phone_number()` / `open_contact()` calls with `request_contact()` and a `BackgroundEvent::ContactRequested` listener.
+- Drop any `join_voice_chat` calls — voice chats were never reachable through the WebApp JS bridge.
+- Replace `BackgroundEvent::PhoneRequested` subscriptions with `BackgroundEvent::ContactRequested`.
+
 ## [0.3.0] - 2025-11-04
 ### Removed
 - **BREAKING:** Removed server-side validation logic from SDK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.5.0"
+version = "0.6.0"
 rust-version = "1.94.1"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION
## Summary

Release `0.6.0`.

- Bump `Cargo.toml` version `0.5.0 → 0.6.0` (also reflected in `Cargo.lock`).
- Promote the `[Unreleased]` slot in `CHANGELOG.md` to `## [0.6.0] - 2026-05-13` summarising #184, #185, #188 with a Migration Guide for the removed phantom methods.

## After merge (owner action)

1. `cargo make tag` — creates `v0.6.0` from `Cargo.toml`.
2. `git push origin v0.6.0` — triggers `.github/workflows/release.yml` to run CI, `cargo publish`, and create the GitHub Release with git-cliff–generated notes.

I deliberately do **not** push the tag here — publishing to crates.io is irreversible and should go through an explicit owner step.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green