### PR TITLE
192

### DIFF
--- a/src/dom/document.rs
+++ b/src/dom/document.rs
@@ -41,3 +41,74 @@ impl Default for Doc {
         Self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::Element;
+
+    use super::*;
+    use crate::dom::ElementExt;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn fresh_root(id: &str) -> Element {
+        let doc = Doc;
+        let body = doc.body().expect("body");
+        let container = doc.create_element("div").expect("create container");
+        container.set_id(id);
+        body.append_child(&container).expect("append container");
+        container
+    }
+
+    fn cleanup(root: &Element) {
+        root.remove();
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn create_element_returns_tagged() {
+        let el = Doc.create_element("section").expect("create");
+        assert_eq!(el.tag_name().to_ascii_lowercase(), "section");
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn get_element_by_id_finds_existing_and_misses() {
+        let root = fresh_root("doc-test-get-by-id");
+        assert!(Doc.get_element_by_id("doc-test-get-by-id").is_some());
+        assert!(Doc.get_element_by_id("doc-test-absent").is_none());
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn query_selector_finds_and_misses() {
+        let root = fresh_root("doc-test-qs");
+        let child = Doc.create_element("span").expect("span");
+        child.set_class("hit");
+        root.append_child(&child).expect("append");
+
+        let found = Doc.query_selector("#doc-test-qs .hit").expect("ok");
+        assert!(found.is_some());
+        let absent = Doc.query_selector("#doc-test-qs .nope").expect("ok");
+        assert!(absent.is_none());
+
+        cleanup(&root);
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn query_selector_invalid_returns_err() {
+        assert!(Doc.query_selector(">>>broken<<<").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn body_returns_html_element() {
+        let body = Doc.body().expect("body");
+        let as_el: &Element = body.unchecked_ref();
+        assert_eq!(as_el.tag_name().to_ascii_lowercase(), "body");
+    }
+}

--- a/src/dom/element.rs
+++ b/src/dom/element.rs
@@ -145,3 +145,198 @@ impl ElementExt for Element {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::Element;
+
+    use super::*;
+    use crate::dom::Document;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn make(tag: &str) -> Element {
+        Document.create_element(tag).expect("create")
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn set_class_sets_attribute() {
+        let el = make("div");
+        el.set_class("a b");
+        assert_eq!(el.get_attribute("class").as_deref(), Some("a b"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn set_id_sets_attribute() {
+        let el = make("div");
+        el.set_id("x");
+        assert_eq!(el.get_attribute("id").as_deref(), Some("x"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn set_text_sets_text_content() {
+        let el = make("p");
+        el.set_text("hello");
+        assert_eq!(el.text_content().as_deref(), Some("hello"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn set_html_sets_inner_html() {
+        let el = make("div");
+        el.set_html("<b>bold</b>").expect("ok");
+        assert!(el.inner_html().contains("<b>"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn set_and_get_attr() {
+        let el = make("div");
+        el.set_attr("data-x", "42").expect("ok");
+        assert_eq!(el.get_attr("data-x").as_deref(), Some("42"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn remove_attr_clears_value() {
+        let el = make("div");
+        el.set_attr("data-x", "42").expect("ok");
+        el.remove_attr("data-x").expect("ok");
+        assert!(el.get_attr("data-x").is_none());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn add_class_appends_and_dedupes() {
+        let el = make("div");
+        el.add_class("a").expect("ok");
+        el.add_class("b").expect("ok");
+        el.add_class("a").expect("ok");
+        assert_eq!(el.get_attribute("class").as_deref(), Some("a b"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn remove_class_filters_and_clears_when_empty() {
+        let el = make("div");
+        el.set_class("a b");
+        el.remove_class("a").expect("ok");
+        assert_eq!(el.get_attribute("class").as_deref(), Some("b"));
+        el.remove_class("b").expect("ok");
+        assert!(el.get_attribute("class").is_none());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn toggle_class_round_trip() {
+        let el = make("div");
+        el.toggle_class("on").expect("ok");
+        assert!(el.has_class("on"));
+        el.toggle_class("on").expect("ok");
+        assert!(!el.has_class("on"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn has_class_finds_only_whole_tokens() {
+        let el = make("div");
+        el.set_class("alpha beta");
+        assert!(el.has_class("alpha"));
+        assert!(el.has_class("beta"));
+        assert!(!el.has_class("alph"));
+        assert!(!el.has_class("gamma"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn on_event_fires_handler() {
+        let body = Document.body().expect("body");
+        let el = make("button");
+        body.append_child(&el).expect("attach");
+
+        let hits = Rc::new(Cell::new(0u32));
+        let hits_cb = hits.clone();
+        el.on("click", move |_| hits_cb.set(hits_cb.get() + 1))
+            .expect("ok");
+
+        let evt = web_sys::Event::new("click").expect("event");
+        el.dispatch_event(&evt).expect("dispatch");
+
+        assert_eq!(hits.get(), 1);
+        el.remove();
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn append_places_child_at_end() {
+        let parent = make("ul");
+        let a = make("li");
+        a.set_id("a");
+        let b = make("li");
+        b.set_id("b");
+        parent.append(&a).expect("ok");
+        parent.append(&b).expect("ok");
+
+        let last = parent.last_element_child().expect("last");
+        assert_eq!(last.id(), "b");
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn prepend_inserts_at_start_or_appends_when_empty() {
+        let parent = make("ul");
+        let a = make("li");
+        a.set_id("a");
+        parent.prepend(&a).expect("ok");
+        assert_eq!(parent.first_element_child().expect("first").id(), "a");
+
+        let b = make("li");
+        b.set_id("b");
+        parent.prepend(&b).expect("ok");
+        assert_eq!(parent.first_element_child().expect("first").id(), "b");
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn remove_detaches_and_is_noop_without_parent() {
+        let parent = make("div");
+        let child = make("span");
+        parent.append(&child).expect("ok");
+        assert!(parent.first_element_child().is_some());
+        // UFCS because `web_sys::Element::remove` also exists and shadows the trait
+        // method.
+        ElementExt::remove(&child).expect("detach");
+        assert!(parent.first_element_child().is_none());
+
+        let orphan = make("div");
+        ElementExt::remove(&orphan).expect("noop");
+    }
+
+    fn element_child_count(parent: &Element) -> usize {
+        let mut count = 0usize;
+        let mut next = parent.first_element_child();
+        while let Some(el) = next {
+            count += 1;
+            next = el.next_element_sibling();
+        }
+        count
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn clear_removes_all_children() {
+        let parent = make("div");
+        for _ in 0..3 {
+            parent.append(&make("span")).expect("ok");
+        }
+        assert_eq!(element_child_count(&parent), 3);
+        parent.clear();
+        assert_eq!(element_child_count(&parent), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Add `wasm_bindgen_test` coverage for `dom::Document` and `ElementExt` (landed in #184 without tests).

### `src/dom/document.rs::tests`
- `create_element_returns_tagged`
- `get_element_by_id_finds_existing_and_misses`
- `query_selector_finds_and_misses`
- `query_selector_invalid_returns_err`
- `body_returns_html_element`

### `src/dom/element.rs::tests`
- `set_class_sets_attribute`, `set_id_sets_attribute`, `set_text_sets_text_content`, `set_html_sets_inner_html`
- `set_and_get_attr`, `remove_attr_clears_value`
- `add_class_appends_and_dedupes`, `remove_class_filters_and_clears_when_empty`
- `toggle_class_round_trip`, `has_class_finds_only_whole_tokens`
- `on_event_fires_handler` (dispatches a synthetic `click` and asserts the closure ran)
- `append_places_child_at_end`, `prepend_inserts_at_start_or_appends_when_empty`
- `remove_detaches_and_is_noop_without_parent` (uses UFCS `ElementExt::remove(&el)` because `web_sys::Element::remove` shadows the trait method)
- `clear_removes_all_children`

## Test plan

- [x] `cargo test --no-run --lib --all-features -p telegram-webapp-sdk` (compiles)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green (executes `wasm-bindgen-test` jobs end-to-end)