### PR TITLE
194

### DIFF
--- a/src/webapp/dialogs.rs
+++ b/src/webapp/dialogs.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
-use js_sys::{Function, Reflect};
+use js_sys::{Function, Object, Reflect};
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 
 use crate::webapp::TelegramWebApp;
@@ -60,7 +60,10 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.showScanQrPopup(text, callback)`.
+    /// Call `WebApp.showScanQrPopup({ text }, callback)`.
+    ///
+    /// The text is shown above the scanner viewport. Pass an empty string to
+    /// open the scanner without a caption.
     ///
     /// # Examples
     /// ```no_run
@@ -78,9 +81,11 @@ impl TelegramWebApp {
         let cb = Closure::<dyn FnMut(JsValue)>::new(move |value: JsValue| {
             callback(value.as_string().unwrap_or_default());
         });
+        let params = Object::new();
+        Reflect::set(&params, &"text".into(), &text.into())?;
         Reflect::get(&self.inner, &"showScanQrPopup".into())?
             .dyn_into::<Function>()?
-            .call2(&self.inner, &text.into(), cb.as_ref().unchecked_ref())?;
+            .call2(&self.inner, &params, cb.as_ref().unchecked_ref())?;
         cb.forget();
         Ok(())
     }
@@ -98,5 +103,65 @@ impl TelegramWebApp {
             .dyn_into::<Function>()?
             .call0(&self.inner)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use crate::webapp::TelegramWebApp;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn setup_webapp() -> Object {
+        let win = window().expect("window");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn show_scan_qr_popup_passes_params_as_object_with_text() {
+        let webapp = setup_webapp();
+        let capture = Function::new_with_args("params, _cb", "this.captured_params = params;");
+        let _ = Reflect::set(&webapp, &"showScanQrPopup".into(), &capture);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        app.show_scan_qr_popup("Scan", |_| {}).expect("ok");
+
+        let params = Reflect::get(&webapp, &"captured_params".into()).expect("captured");
+        assert!(!params.is_undefined(), "scan params must be an object");
+        let text = Reflect::get(&params, &"text".into())
+            .expect("text field")
+            .as_string();
+        assert_eq!(text.as_deref(), Some("Scan"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn show_scan_qr_popup_callback_receives_scanned_text() {
+        let webapp = setup_webapp();
+        // Synchronously invoke the callback with a scanned value so we can
+        // observe it without scheduling.
+        let invoke = Function::new_with_args("_params, cb", "cb('payload');");
+        let _ = Reflect::set(&webapp, &"showScanQrPopup".into(), &invoke);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        let captured = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+        let captured_ref = captured.clone();
+        app.show_scan_qr_popup("", move |t| {
+            *captured_ref.borrow_mut() = t;
+        })
+        .expect("ok");
+
+        assert_eq!(captured.borrow().as_str(), "payload");
+        let _ = JsValue::null();
     }
 }


### PR DESCRIPTION
## Bug

`TelegramWebApp::show_scan_qr_popup(text: &str, callback)` passed the raw string as the first argument to `WebApp.showScanQrPopup`, but JS expects an **object** `{ text }`:

```js
WebApp.showScanQrPopup = function (params, callback) {
  if (typeof params.text !== 'undefined') { /* ... */ }
};
```

Since the string had no `.text` property, the caption was silently dropped on every call.

## Fix

Wrap `text` into a `js_sys::Object` with a `text` field before invoking JS. Public signature unchanged — only the on-the-wire payload becomes correct.

Added two `wasm_bindgen_test` cases:
- `show_scan_qr_popup_passes_params_as_object_with_text` — asserts the captured first argument is an object with `text === "Scan"`.
- `show_scan_qr_popup_callback_receives_scanned_text` — round-trips a synthetic scanned value through the callback.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo test --no-run --lib --all-features -p telegram-webapp-sdk` (new wasm tests compile)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green