### PR TITLE
196

### DIFF
--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -17,7 +17,7 @@ mod viewport;
 
 // Re-export public types
 pub use types::{
-    BackgroundEvent, BottomButton, BottomButtonParams, EventHandle, OpenLinkOptions,
+    BackgroundEvent, BottomButton, BottomButtonParams, CloseOptions, EventHandle, OpenLinkOptions,
     SafeAreaInset, SecondaryButtonParams, SecondaryButtonPosition
 };
 

--- a/src/webapp/core.rs
+++ b/src/webapp/core.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use js_sys::{Function, Object, Reflect};
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::window;
 
 use crate::{core::context::TelegramContext, webapp::TelegramWebApp};
@@ -95,6 +95,56 @@ impl TelegramWebApp {
         self.call0("ready")
     }
 
+    /// Call `WebApp.invokeCustomMethod(method, params, callback)`.
+    ///
+    /// The JS callback is `(error, result)`; the wrapper translates it into
+    /// `Result<JsValue, JsValue>` for the Rust closure.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use js_sys::Object;
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// let params = Object::new();
+    /// app.invoke_custom_method("getRequestedContact", &params.into(), |outcome| {
+    ///     let _ = outcome;
+    /// })
+    /// .unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn invoke_custom_method<F>(
+        &self,
+        method: &str,
+        params: &JsValue,
+        callback: F
+    ) -> Result<(), JsValue>
+    where
+        F: 'static + Fn(Result<JsValue, JsValue>)
+    {
+        let cb =
+            Closure::<dyn FnMut(JsValue, JsValue)>::new(move |err: JsValue, result: JsValue| {
+                if err.is_null() || err.is_undefined() {
+                    callback(Ok(result));
+                } else {
+                    callback(Err(err));
+                }
+            });
+        let f = Reflect::get(&self.inner, &"invokeCustomMethod".into())?;
+        let func = f
+            .dyn_ref::<Function>()
+            .ok_or_else(|| JsValue::from_str("invokeCustomMethod is not a function"))?;
+        func.call3(
+            &self.inner,
+            &method.into(),
+            params,
+            cb.as_ref().unchecked_ref()
+        )?;
+        cb.forget();
+        Ok(())
+    }
+
     // === Internal helper methods ===
 
     pub(super) fn call0(&self, method: &str) -> Result<(), JsValue> {
@@ -123,5 +173,79 @@ impl TelegramWebApp {
             .ok_or_else(|| JsValue::from_str("not a function"))?;
         func.call0(&obj)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use crate::webapp::TelegramWebApp;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn setup_webapp() -> Object {
+        let win = window().expect("window");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn invoke_custom_method_passes_args_and_delivers_result() {
+        let webapp = setup_webapp();
+        let invoke = Function::new_with_args(
+            "method, params, cb",
+            "this.method = method; this.params = params; cb(null, {ok: 1});"
+        );
+        let _ = Reflect::set(&webapp, &"invokeCustomMethod".into(), &invoke);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        let received = Rc::new(RefCell::new(None::<JsValue>));
+        let cap = received.clone();
+        let params = Object::new();
+        let _ = Reflect::set(&params, &"x".into(), &"y".into());
+        app.invoke_custom_method("doStuff", &params.into(), move |out| {
+            *cap.borrow_mut() = Some(out.expect("ok"));
+        })
+        .expect("ok");
+
+        assert_eq!(
+            Reflect::get(&webapp, &"method".into())
+                .unwrap()
+                .as_string()
+                .as_deref(),
+            Some("doStuff")
+        );
+        let value = received.borrow().clone().expect("result");
+        let ok_val = Reflect::get(&value, &"ok".into()).expect("ok field");
+        assert_eq!(ok_val.as_f64(), Some(1.0));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn invoke_custom_method_translates_error() {
+        let webapp = setup_webapp();
+        let invoke = Function::new_with_args("_method, _params, cb", "cb('boom', null);");
+        let _ = Reflect::set(&webapp, &"invokeCustomMethod".into(), &invoke);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        let received = Rc::new(RefCell::new(None::<JsValue>));
+        let cap = received.clone();
+        app.invoke_custom_method("doStuff", &JsValue::NULL, move |out| {
+            *cap.borrow_mut() = Some(out.expect_err("err"));
+        })
+        .expect("ok");
+
+        let err = received.borrow().clone().expect("err");
+        assert_eq!(err.as_string().as_deref(), Some("boom"));
     }
 }

--- a/src/webapp/lifecycle.rs
+++ b/src/webapp/lifecycle.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
-use js_sys::Reflect;
-use wasm_bindgen::JsValue;
+use js_sys::{Function, Reflect};
+use serde_wasm_bindgen::to_value;
+use wasm_bindgen::{JsCast, JsValue};
 
-use crate::webapp::TelegramWebApp;
+use crate::webapp::{TelegramWebApp, types::CloseOptions};
 
 impl TelegramWebApp {
     /// Call `WebApp.expand()`.
@@ -21,6 +22,33 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn close(&self) -> Result<(), JsValue> {
         self.call0("close")
+    }
+
+    /// Call `WebApp.close(options)` (Bot API 7.6+ for `return_back`).
+    ///
+    /// On older Telegram clients the option is silently ignored on the JS side.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::{CloseOptions, TelegramWebApp};
+    /// # let app = TelegramWebApp::instance().unwrap();
+    /// app.close_with_options(&CloseOptions {
+    ///     return_back: Some(true)
+    /// })
+    /// .unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails or the options fail
+    /// to serialize.
+    pub fn close_with_options(&self, options: &CloseOptions) -> Result<(), JsValue> {
+        let payload = to_value(options).map_err(|err| JsValue::from_str(&err.to_string()))?;
+        let f = Reflect::get(&self.inner, &"close".into())?;
+        let func = f
+            .dyn_ref::<Function>()
+            .ok_or_else(|| JsValue::from_str("close is not a function"))?;
+        func.call1(&self.inner, &payload)?;
+        Ok(())
     }
 
     /// Call `WebApp.enableClosingConfirmation()`.
@@ -231,5 +259,59 @@ impl TelegramWebApp {
             .ok()
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use crate::webapp::{TelegramWebApp, types::CloseOptions};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn setup_webapp() -> Object {
+        let win = window().expect("window");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn close_with_options_passes_return_back() {
+        let webapp = setup_webapp();
+        let capture = Function::new_with_args("opts", "this.captured_close = opts;");
+        let _ = Reflect::set(&webapp, &"close".into(), &capture);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        app.close_with_options(&CloseOptions {
+            return_back: Some(true)
+        })
+        .expect("ok");
+
+        let opts = Reflect::get(&webapp, &"captured_close".into()).expect("captured");
+        let val = Reflect::get(&opts, &"return_back".into()).expect("field");
+        assert_eq!(val.as_bool(), Some(true));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn close_with_options_omits_unset_fields() {
+        let webapp = setup_webapp();
+        let capture = Function::new_with_args("opts", "this.captured_close = opts;");
+        let _ = Reflect::set(&webapp, &"close".into(), &capture);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        app.close_with_options(&CloseOptions::default())
+            .expect("ok");
+
+        let opts = Reflect::get(&webapp, &"captured_close".into()).expect("captured");
+        let val = Reflect::get(&opts, &"return_back".into()).expect("field");
+        assert!(val.is_undefined());
     }
 }

--- a/src/webapp/theme.rs
+++ b/src/webapp/theme.rs
@@ -1,11 +1,55 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+use js_sys::Reflect;
 use wasm_bindgen::JsValue;
 
 use crate::webapp::TelegramWebApp;
 
 impl TelegramWebApp {
+    /// Returns `WebApp.colorScheme` — `"light"` or `"dark"`.
+    pub fn color_scheme(&self) -> Option<String> {
+        Reflect::get(&self.inner, &"colorScheme".into())
+            .ok()
+            .and_then(|v| v.as_string())
+    }
+
+    /// Returns the current `WebApp.headerColor` value.
+    pub fn header_color(&self) -> Option<String> {
+        Reflect::get(&self.inner, &"headerColor".into())
+            .ok()
+            .and_then(|v| v.as_string())
+    }
+
+    /// Returns the current `WebApp.backgroundColor` value.
+    pub fn background_color(&self) -> Option<String> {
+        Reflect::get(&self.inner, &"backgroundColor".into())
+            .ok()
+            .and_then(|v| v.as_string())
+    }
+
+    /// Returns the current `WebApp.bottomBarColor` value (Bot API 7.10+).
+    pub fn bottom_bar_color(&self) -> Option<String> {
+        Reflect::get(&self.inner, &"bottomBarColor".into())
+            .ok()
+            .and_then(|v| v.as_string())
+    }
+
+    /// Returns the raw `WebApp.version` string (e.g. `"9.6"`).
+    pub fn raw_version(&self) -> Option<String> {
+        Reflect::get(&self.inner, &"version".into())
+            .ok()
+            .and_then(|v| v.as_string())
+    }
+
+    /// Returns the `WebApp.platform` string (e.g. `"tdesktop"`, `"ios"`,
+    /// `"web"`).
+    pub fn platform(&self) -> Option<String> {
+        Reflect::get(&self.inner, &"platform".into())
+            .ok()
+            .and_then(|v| v.as_string())
+    }
+
     /// Call `WebApp.setHeaderColor(color)`.
     ///
     /// # Errors
@@ -49,5 +93,54 @@ impl TelegramWebApp {
     /// ```
     pub fn set_bottom_bar_color(&self, color: &str) -> Result<(), JsValue> {
         self.call1("setBottomBarColor", &color.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Object, Reflect};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use crate::webapp::TelegramWebApp;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn setup_webapp() -> Object {
+        let win = window().expect("window");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn property_getters_read_string_values() {
+        let webapp = setup_webapp();
+        let _ = Reflect::set(&webapp, &"colorScheme".into(), &"dark".into());
+        let _ = Reflect::set(&webapp, &"headerColor".into(), &"#111111".into());
+        let _ = Reflect::set(&webapp, &"backgroundColor".into(), &"#222222".into());
+        let _ = Reflect::set(&webapp, &"bottomBarColor".into(), &"#333333".into());
+        let _ = Reflect::set(&webapp, &"version".into(), &"9.6".into());
+        let _ = Reflect::set(&webapp, &"platform".into(), &"tdesktop".into());
+
+        let app = TelegramWebApp::instance().expect("instance");
+        assert_eq!(app.color_scheme().as_deref(), Some("dark"));
+        assert_eq!(app.header_color().as_deref(), Some("#111111"));
+        assert_eq!(app.background_color().as_deref(), Some("#222222"));
+        assert_eq!(app.bottom_bar_color().as_deref(), Some("#333333"));
+        assert_eq!(app.raw_version().as_deref(), Some("9.6"));
+        assert_eq!(app.platform().as_deref(), Some("tdesktop"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn property_getters_return_none_when_absent() {
+        let _webapp = setup_webapp();
+        let app = TelegramWebApp::instance().expect("instance");
+        assert!(app.color_scheme().is_none());
+        assert!(app.platform().is_none());
     }
 }

--- a/src/webapp/types.rs
+++ b/src/webapp/types.rs
@@ -304,7 +304,8 @@ pub struct SecondaryButtonParams<'a> {
 ///
 /// if let Some(app) = TelegramWebApp::instance() {
 ///     let options = OpenLinkOptions {
-///         try_instant_view: Some(true)
+///         try_instant_view: Some(true),
+///         try_browser:      None
 ///     };
 ///     let _ = app.open_link("https://example.com", Some(&options));
 /// }
@@ -312,7 +313,31 @@ pub struct SecondaryButtonParams<'a> {
 #[derive(Debug, Default, Serialize)]
 pub struct OpenLinkOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub try_instant_view: Option<bool>
+    pub try_instant_view: Option<bool>,
+    /// Preferred external browser (Bot API 7.6+). Pass values like `"chrome"`,
+    /// `"firefox"`, `"safari"`. Ignored by older clients.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub try_browser:      Option<String>
+}
+
+/// Options supported by [`crate::webapp::TelegramWebApp::close_with_options`].
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::webapp::{CloseOptions, TelegramWebApp};
+///
+/// if let Some(app) = TelegramWebApp::instance() {
+///     let _ = app.close_with_options(&CloseOptions {
+///         return_back: Some(true)
+///     });
+/// }
+/// ```
+#[derive(Debug, Default, Serialize)]
+pub struct CloseOptions {
+    /// If `true` and the host client is Bot API 7.6+, returns the user to the
+    /// previous chat instead of just closing the mini app.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_back: Option<bool>
 }
 
 /// Background events delivered by Telegram when the Mini App runs in the


### PR DESCRIPTION
## Summary

Cover the remaining `Telegram.WebApp` surface that the crate was missing or under-exposing (audited against `https://telegram.org/js/telegram-web-app.js`, 3392 lines).

### New methods on `TelegramWebApp`

- `invoke_custom_method(method, params, callback)` → `WebApp.invokeCustomMethod`. Translates the JS `(error, result)` callback into a Rust `Result<JsValue, JsValue>`.
- `close_with_options(&CloseOptions)` → `WebApp.close(options)` with `return_back` (Bot API 7.6+). The parameterless `close()` is kept unchanged.

### Property getters on `TelegramWebApp`

Mirror `Object.defineProperty(WebApp, ...)` getters that previously had only setters or nothing at all:

- `color_scheme()`
- `header_color()`, `background_color()`, `bottom_bar_color()`
- `raw_version()`, `platform()`

### Types

- `webapp::types::CloseOptions { return_back: Option<bool> }` (re-exported via `webapp::CloseOptions`).
- `OpenLinkOptions` gains `try_browser: Option<String>` (Bot API 7.6+). Additive — `Default` still works.

### Tests

`wasm_bindgen_test` cases in the touched modules:
- `webapp/core.rs`: `invoke_custom_method_passes_args_and_delivers_result`, `invoke_custom_method_translates_error`.
- `webapp/lifecycle.rs`: `close_with_options_passes_return_back`, `close_with_options_omits_unset_fields`.
- `webapp/theme.rs`: `property_getters_read_string_values`, `property_getters_return_none_when_absent`.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native)
- [x] `cargo test --no-run --lib --all-features -p telegram-webapp-sdk` (new wasm tests compile)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green