### PR TITLE
198

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-13
+### Changed
+- **MSRV:** minimum supported Rust version raised `1.94.1 → 1.95.0` (#198).
+
+### Fixed
+- `TelegramWebApp::show_scan_qr_popup` now wraps the prompt text in `{ text }` so the caption above the QR scanner reaches Telegram (#195).
+
+### Added
+- `TelegramWebApp::invoke_custom_method(method, params, callback)` — wraps `WebApp.invokeCustomMethod` and translates the `(error, result)` JS callback into `Result<JsValue, JsValue>` (#197).
+- `TelegramWebApp::close_with_options(&CloseOptions)` and `webapp::CloseOptions { return_back }` for `WebApp.close(options)` (Bot API 7.6+ for `return_back`) (#197).
+- `OpenLinkOptions::try_browser` field (Bot API 7.6+) (#197).
+- `TelegramWebApp` property getters: `color_scheme`, `header_color`, `background_color`, `bottom_bar_color`, `raw_version`, `platform` (#197).
+- `wasm_bindgen_test` coverage for `dom::Document` and `ElementExt` (#193).
+
 ## [0.6.0] - 2026-05-13
 ### Added
 - `dom` module with `Document` and `ElementExt` ergonomic helpers for vanilla WASM users (#184).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.6.0"
-rust-version = "1.94.1"
+version = "0.7.0"
+rust-version = "1.95.0"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"
 license = "MIT"
@@ -12,7 +12,7 @@ keywords = ["telegram", "webapp", "wasm", "sdk"]
 categories = ["web-programming", "wasm"]
 
 [workspace.package]
-rust-version = "1.94.1"
+rust-version = "1.95.0"
 
 [workspace.dependencies]
 inventory = "0.3"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![docs.rs](https://img.shields.io/docsrs/telegram-webapp-sdk)](https://docs.rs/telegram-webapp-sdk)
 [![Downloads](https://img.shields.io/crates/d/telegram-webapp-sdk)](https://crates.io/crates/telegram-webapp-sdk)
 <!-- msrv_badge:start -->
-![MSRV](https://img.shields.io/badge/MSRV-1.91-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)
 <!-- msrv_badge:end -->
 ![License](https://img.shields.io/badge/License-MIT-informational)
 [![codecov](https://codecov.io/gh/RAprogramm/telegram-webapp-sdk/graph/badge.svg?token=7FP6HC20BK)](https://codecov.io/gh/RAprogramm/telegram-webapp-sdk)


### PR DESCRIPTION
## Summary

Release `0.7.0`. Minor bump because MSRV is raised (per Cargo's MSRV-as-semver convention).

- `Cargo.toml`: package `version 0.6.0 → 0.7.0`, `rust-version 1.94.1 → 1.95.0` (also in `workspace.package`).
- `README.md`: MSRV badge `1.91 → 1.95`. (`update_readme` bin can't be auto-run here because its `reqwest` lacks TLS features — pre-existing, separate issue.)
- `CHANGELOG.md`: promote `[Unreleased]` to `## [0.7.0] - 2026-05-13`:
  - **Changed (MSRV):** minimum Rust `1.94.1 → 1.95.0`.
  - **Fixed:** scan-QR popup caption fix (#195).
  - **Added:** `invoke_custom_method`, `close_with_options` + `CloseOptions`, `OpenLinkOptions::try_browser`, six property getters (#197), `dom` test coverage (#193).

## After merge

Owner-only:
1. `cargo make tag` → `v0.7.0`.
2. `git push origin v0.7.0` → triggers `release.yml` (CI → `cargo publish` → GitHub Release).

Crates.io publication is irreversible; left as an explicit owner step.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green (jobs auto-pick MSRV 1.95.0 from `Cargo.toml`)