### PR TITLE
200

### DIFF
--- a/src/webapp/dialogs.rs
+++ b/src/webapp/dialogs.rs
@@ -146,6 +146,68 @@ mod tests {
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
+    fn show_alert_passes_message() {
+        let webapp = setup_webapp();
+        let capture = Function::new_with_args("msg", "this.captured_alert = msg;");
+        let _ = Reflect::set(&webapp, &"showAlert".into(), &capture);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        app.show_alert("Heads up").expect("ok");
+
+        assert_eq!(
+            Reflect::get(&webapp, &"captured_alert".into())
+                .unwrap()
+                .as_string()
+                .as_deref(),
+            Some("Heads up")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn show_confirm_passes_message_and_routes_boolean_back() {
+        let webapp = setup_webapp();
+        let invoke = Function::new_with_args("msg, cb", "this.captured_confirm = msg; cb(true);");
+        let _ = Reflect::set(&webapp, &"showConfirm".into(), &invoke);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        let received = std::rc::Rc::new(std::cell::Cell::new(false));
+        let received_ref = received.clone();
+        app.show_confirm("Proceed?", move |ok| received_ref.set(ok))
+            .expect("ok");
+
+        assert_eq!(
+            Reflect::get(&webapp, &"captured_confirm".into())
+                .unwrap()
+                .as_string()
+                .as_deref(),
+            Some("Proceed?")
+        );
+        assert!(received.get());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn close_scan_qr_popup_calls_js() {
+        let webapp = setup_webapp();
+        let called = std::rc::Rc::new(std::cell::Cell::new(false));
+        let called_ref = called.clone();
+        let close =
+            wasm_bindgen::closure::Closure::<dyn FnMut()>::new(move || called_ref.set(true));
+        let _ = Reflect::set(
+            &webapp,
+            &"closeScanQrPopup".into(),
+            wasm_bindgen::JsCast::unchecked_ref::<Function>(close.as_ref())
+        );
+        close.forget();
+
+        let app = TelegramWebApp::instance().expect("instance");
+        app.close_scan_qr_popup().expect("ok");
+        assert!(called.get());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
     fn show_scan_qr_popup_callback_receives_scanned_text() {
         let webapp = setup_webapp();
         // Synchronously invoke the callback with a scanned value so we can

--- a/src/webapp/events.rs
+++ b/src/webapp/events.rs
@@ -277,3 +277,46 @@ impl TelegramWebApp {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use js_sys::{Function, Object, Reflect};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use crate::webapp::TelegramWebApp;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn setup_webapp() -> Object {
+        let win = window().expect("window");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let on_event = Function::new_with_args("name, cb", "this[name] = cb;");
+        let off_event = Function::new_with_args("name", "delete this[name];");
+        let _ = Reflect::set(&webapp, &"onEvent".into(), &on_event);
+        let _ = Reflect::set(&webapp, &"offEvent".into(), &off_event);
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn on_content_safe_area_changed_registers_and_unregisters() {
+        let webapp = setup_webapp();
+        let app = TelegramWebApp::instance().expect("instance");
+
+        let handle = app.on_content_safe_area_changed(|| {}).expect("subscribe");
+        assert!(
+            Reflect::has(&webapp, &"contentSafeAreaChanged".into()).unwrap_or(false),
+            "callback should be registered under the event name"
+        );
+
+        app.off_event(handle).expect("unsubscribe");
+        assert!(
+            !Reflect::has(&webapp, &"contentSafeAreaChanged".into()).unwrap_or(true),
+            "callback should be removed"
+        );
+    }
+}

--- a/src/webapp/viewport.rs
+++ b/src/webapp/viewport.rs
@@ -90,3 +90,90 @@ impl TelegramWebApp {
         self.safe_area_from_property("contentSafeAreaInset")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use js_sys::{Object, Reflect};
+    use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    use crate::webapp::TelegramWebApp;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn setup_webapp() -> Object {
+        let win = window().expect("window");
+        let telegram = Object::new();
+        let webapp = Object::new();
+        let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
+        let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
+        webapp
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn viewport_height_returns_f64() {
+        let webapp = setup_webapp();
+        let _ = Reflect::set(&webapp, &"viewportHeight".into(), &JsValue::from_f64(640.0));
+        let app = TelegramWebApp::instance().expect("instance");
+        assert_eq!(app.viewport_height(), Some(640.0));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn viewport_height_returns_none_when_property_missing() {
+        let _ = setup_webapp();
+        let app = TelegramWebApp::instance().expect("instance");
+        assert!(app.viewport_height().is_none());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn viewport_width_reads_viewport_width_property() {
+        // NOTE: real Telegram does not expose `viewportWidth`; this test pins
+        // current crate behaviour so a future removal is intentional.
+        let webapp = setup_webapp();
+        let _ = Reflect::set(&webapp, &"viewportWidth".into(), &JsValue::from_f64(360.0));
+        let app = TelegramWebApp::instance().expect("instance");
+        assert_eq!(app.viewport_width(), Some(360.0));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn viewport_stable_height_returns_f64() {
+        let webapp = setup_webapp();
+        let _ = Reflect::set(
+            &webapp,
+            &"viewportStableHeight".into(),
+            &JsValue::from_f64(600.0)
+        );
+        let app = TelegramWebApp::instance().expect("instance");
+        assert_eq!(app.viewport_stable_height(), Some(600.0));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn expand_viewport_calls_js_expand() {
+        let webapp = setup_webapp();
+        let called = Rc::new(Cell::new(false));
+        let called_ref = called.clone();
+        let cb = Closure::<dyn FnMut()>::new(move || called_ref.set(true));
+        let _ = Reflect::set(&webapp, &"expand".into(), cb.as_ref().unchecked_ref());
+        cb.forget();
+
+        let app = TelegramWebApp::instance().expect("instance");
+        app.expand_viewport().expect("ok");
+        assert!(called.get());
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    fn expand_viewport_errors_when_method_missing() {
+        let _ = setup_webapp();
+        let app = TelegramWebApp::instance().expect("instance");
+        assert!(app.expand_viewport().is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Backfill `wasm_bindgen_test` coverage on the public surface that was missing it after the 0.7.0 audit. Stabilises behaviour before the planned RAII pass over `cb.forget()`.

### `src/webapp/viewport.rs::tests`
- `viewport_height_returns_f64`
- `viewport_height_returns_none_when_property_missing`
- `viewport_width_reads_viewport_width_property` (pins current behaviour — see note below)
- `viewport_stable_height_returns_f64`
- `expand_viewport_calls_js_expand`
- `expand_viewport_errors_when_method_missing`

### `src/webapp/dialogs.rs::tests`
- `show_alert_passes_message`
- `show_confirm_passes_message_and_routes_boolean_back`
- `close_scan_qr_popup_calls_js`

### `src/webapp/events.rs::tests`
- `on_content_safe_area_changed_registers_and_unregisters` (also exercises `off_event`)

### Note on `viewport_width`
Upstream `telegram-web-app.js` does **not** expose a `viewportWidth` property — only `viewportHeight` and `viewportStableHeight`. `TelegramWebApp::viewport_width` therefore returns `None` in real Telegram. Captured here with a behaviour-pinning test; intentional removal/deprecation will be its own issue so it can be considered alongside the 0.8.0 cycle.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native)
- [x] `cargo test --no-run --lib --all-features -p telegram-webapp-sdk` (new wasm tests compile)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green