### PR TITLE
202

### DIFF
--- a/src/webapp/core.rs
+++ b/src/webapp/core.rs
@@ -121,27 +121,20 @@ impl TelegramWebApp {
         callback: F
     ) -> Result<(), JsValue>
     where
-        F: 'static + Fn(Result<JsValue, JsValue>)
+        F: 'static + FnOnce(Result<JsValue, JsValue>)
     {
-        let cb =
-            Closure::<dyn FnMut(JsValue, JsValue)>::new(move |err: JsValue, result: JsValue| {
-                if err.is_null() || err.is_undefined() {
-                    callback(Ok(result));
-                } else {
-                    callback(Err(err));
-                }
-            });
+        let cb = Closure::once_into_js(move |err: JsValue, result: JsValue| {
+            if err.is_null() || err.is_undefined() {
+                callback(Ok(result));
+            } else {
+                callback(Err(err));
+            }
+        });
         let f = Reflect::get(&self.inner, &"invokeCustomMethod".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("invokeCustomMethod is not a function"))?;
-        func.call3(
-            &self.inner,
-            &method.into(),
-            params,
-            cb.as_ref().unchecked_ref()
-        )?;
-        cb.forget();
+        func.call3(&self.inner, &method.into(), params, &cb)?;
         Ok(())
     }
 

--- a/src/webapp/dialogs.rs
+++ b/src/webapp/dialogs.rs
@@ -21,15 +21,16 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn show_confirm<F>(&self, msg: &str, on_confirm: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(bool)
+        F: 'static + FnOnce(bool)
     {
-        let cb = Closure::<dyn FnMut(bool)>::new(on_confirm);
+        let cb = Closure::once_into_js(move |v: JsValue| {
+            on_confirm(v.as_bool().unwrap_or(false));
+        });
         let f = Reflect::get(&self.inner, &"showConfirm".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("showConfirm is not a function"))?;
-        func.call2(&self.inner, &msg.into(), cb.as_ref().unchecked_ref())?;
-        cb.forget(); // safe leak for JS lifetime
+        func.call2(&self.inner, &msg.into(), &cb)?;
         Ok(())
     }
 
@@ -48,15 +49,14 @@ impl TelegramWebApp {
     /// ```
     pub fn show_popup<F>(&self, params: &JsValue, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(String)
+        F: 'static + FnOnce(String)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |id: JsValue| {
+        let cb = Closure::once_into_js(move |id: JsValue| {
             callback(id.as_string().unwrap_or_default());
         });
         Reflect::get(&self.inner, &"showPopup".into())?
             .dyn_into::<Function>()?
-            .call2(&self.inner, params, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+            .call2(&self.inner, params, &cb)?;
         Ok(())
     }
 
@@ -76,17 +76,16 @@ impl TelegramWebApp {
     /// ```
     pub fn show_scan_qr_popup<F>(&self, text: &str, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(String)
+        F: 'static + FnOnce(String)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |value: JsValue| {
+        let cb = Closure::once_into_js(move |value: JsValue| {
             callback(value.as_string().unwrap_or_default());
         });
         let params = Object::new();
         Reflect::set(&params, &"text".into(), &text.into())?;
         Reflect::get(&self.inner, &"showScanQrPopup".into())?
             .dyn_into::<Function>()?
-            .call2(&self.inner, &params, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+            .call2(&self.inner, &params, &cb)?;
         Ok(())
     }
 

--- a/src/webapp/navigation.rs
+++ b/src/webapp/navigation.rs
@@ -91,17 +91,16 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn share_message<F>(&self, msg_id: &str, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(bool)
+        F: 'static + FnOnce(bool)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+        let cb = Closure::once_into_js(move |v: JsValue| {
             callback(v.as_bool().unwrap_or(false));
         });
         let f = Reflect::get(&self.inner, &"shareMessage".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("shareMessage is not a function"))?;
-        func.call2(&self.inner, &msg_id.into(), cb.as_ref().unchecked_ref())?;
-        cb.forget();
+        func.call2(&self.inner, &msg_id.into(), &cb)?;
         Ok(())
     }
 
@@ -182,17 +181,16 @@ impl TelegramWebApp {
     /// running Telegram client predates Bot API 9.6).
     pub fn request_chat<F>(&self, req_id: i32, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(bool)
+        F: 'static + FnOnce(bool)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+        let cb = Closure::once_into_js(move |v: JsValue| {
             callback(v.as_bool().unwrap_or(false));
         });
         let f = Reflect::get(&self.inner, &"requestChat".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("requestChat is not a function"))?;
-        func.call2(&self.inner, &req_id.into(), cb.as_ref().unchecked_ref())?;
-        cb.forget();
+        func.call2(&self.inner, &req_id.into(), &cb)?;
         Ok(())
     }
 
@@ -226,17 +224,16 @@ impl TelegramWebApp {
     /// ```
     pub fn check_home_screen_status<F>(&self, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(String)
+        F: 'static + FnOnce(String)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |status: JsValue| {
+        let cb = Closure::once_into_js(move |status: JsValue| {
             callback(status.as_string().unwrap_or_default());
         });
         let f = Reflect::get(&self.inner, &"checkHomeScreenStatus".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("checkHomeScreenStatus is not a function"))?;
-        func.call1(&self.inner, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+        func.call1(&self.inner, &cb)?;
         Ok(())
     }
 }

--- a/src/webapp/permissions.rs
+++ b/src/webapp/permissions.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use js_sys::{Function, Reflect};
@@ -24,14 +24,12 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn request_write_access<F>(&self, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(bool)
+        F: 'static + FnOnce(bool)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+        let cb = Closure::once_into_js(move |v: JsValue| {
             callback(v.as_bool().unwrap_or(false));
         });
-        self.call1("requestWriteAccess", cb.as_ref().unchecked_ref())?;
-        cb.forget();
-        Ok(())
+        self.call1("requestWriteAccess", &cb)
     }
 
     /// Call `WebApp.requestEmojiStatusAccess(callback)`.
@@ -50,17 +48,16 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn request_emoji_status_access<F>(&self, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(bool)
+        F: 'static + FnOnce(bool)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+        let cb = Closure::once_into_js(move |v: JsValue| {
             callback(v.as_bool().unwrap_or(false));
         });
         let f = Reflect::get(&self.inner, &"requestEmojiStatusAccess".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("requestEmojiStatusAccess is not a function"))?;
-        func.call1(&self.inner, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+        func.call1(&self.inner, &cb)?;
         Ok(())
     }
 
@@ -84,17 +81,16 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn set_emoji_status<F>(&self, status: &JsValue, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(bool)
+        F: 'static + FnOnce(bool)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+        let cb = Closure::once_into_js(move |v: JsValue| {
             callback(v.as_bool().unwrap_or(false));
         });
         let f = Reflect::get(&self.inner, &"setEmojiStatus".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("setEmojiStatus is not a function"))?;
-        func.call2(&self.inner, status, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+        func.call2(&self.inner, status, &cb)?;
         Ok(())
     }
 
@@ -111,15 +107,14 @@ impl TelegramWebApp {
     /// ```
     pub fn open_invoice<F>(&self, url: &str, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(String)
+        F: 'static + FnOnce(String)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |status: JsValue| {
+        let cb = Closure::once_into_js(move |status: JsValue| {
             callback(status.as_string().unwrap_or_default());
         });
         Reflect::get(&self.inner, &"openInvoice".into())?
             .dyn_into::<Function>()?
-            .call2(&self.inner, &url.into(), cb.as_ref().unchecked_ref())?;
-        cb.forget();
+            .call2(&self.inner, &url.into(), &cb)?;
         Ok(())
     }
 
@@ -150,17 +145,16 @@ impl TelegramWebApp {
         callback: F
     ) -> Result<(), JsValue>
     where
-        F: 'static + Fn(String)
+        F: 'static + FnOnce(String)
     {
         let js_params =
             to_value(&params).map_err(|e| JsValue::from_str(&format!("serialize params: {e}")))?;
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |v: JsValue| {
+        let cb = Closure::once_into_js(move |v: JsValue| {
             callback(v.as_string().unwrap_or_default());
         });
         Reflect::get(&self.inner, &"downloadFile".into())?
             .dyn_into::<Function>()?
-            .call2(&self.inner, &js_params, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+            .call2(&self.inner, &js_params, &cb)?;
         Ok(())
     }
 
@@ -180,17 +174,16 @@ impl TelegramWebApp {
     /// Returns [`JsValue`] if the underlying JS call fails.
     pub fn read_text_from_clipboard<F>(&self, callback: F) -> Result<(), JsValue>
     where
-        F: 'static + Fn(String)
+        F: 'static + FnOnce(String)
     {
-        let cb = Closure::<dyn FnMut(JsValue)>::new(move |text: JsValue| {
+        let cb = Closure::once_into_js(move |text: JsValue| {
             callback(text.as_string().unwrap_or_default());
         });
         let f = Reflect::get(&self.inner, &"readTextFromClipboard".into())?;
         let func = f
             .dyn_ref::<Function>()
             .ok_or_else(|| JsValue::from_str("readTextFromClipboard is not a function"))?;
-        func.call1(&self.inner, cb.as_ref().unchecked_ref())?;
-        cb.forget();
+        func.call1(&self.inner, &cb)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Replace the `cb.forget()` leak pattern with `Closure::once_into_js` in the 13 one-shot callback sites listed in #202. JS now owns the boxed closure and deallocates it after the first invocation (or the same accept-the-leak behaviour the crate already had if Telegram never fires the callback).

### Files touched

- `src/webapp/permissions.rs`: `request_write_access`, `request_emoji_status_access`, `set_emoji_status`, `open_invoice`, `download_file`, `read_text_from_clipboard`
- `src/webapp/navigation.rs`: `share_message`, `request_chat`, `check_home_screen_status`
- `src/webapp/dialogs.rs`: `show_confirm`, `show_popup`, `show_scan_qr_popup`
- `src/webapp/core.rs`: `invoke_custom_method`

### API impact

`F: 'static + Fn(...)` → `F: 'static + FnOnce(...)`. Strict expansion — every `Fn`/`FnMut` already implements `FnOnce`, so existing call sites continue to compile. The bound now also accepts callbacks that move captured state out, which was previously rejected.

### Out of scope (kept as `forget()` for sound reasons)

- `src/dom/element.rs::ElementExt::on` — multi-shot event listener (e.g. `click`, `input`); the closure must outlive the element.
- `src/api/{accelerometer,gyroscope,device_orientation}.rs` event subscriptions — multi-shot sensor streams.
- Test-only mocks under `#[cfg(test)]` modules.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native — existing tests already exercise the touched paths)
- [x] `cargo test --no-run --lib --all-features -p telegram-webapp-sdk` (all wasm tests compile)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green