### PR TITLE
204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-13
+### Changed
+- One-shot Telegram callbacks now use `Closure::once_into_js`, so the boxed closure is deallocated after JS invokes it instead of leaking per call. Affects `request_write_access`, `request_emoji_status_access`, `set_emoji_status`, `open_invoice`, `download_file`, `read_text_from_clipboard`, `share_message`, `request_chat`, `check_home_screen_status`, `show_confirm`, `show_popup`, `show_scan_qr_popup`, `invoke_custom_method`. Callback bounds widened `Fn → FnOnce` (strict expansion — existing call sites unaffected) (#203).
+
+### Tests
+- Backfilled `wasm_bindgen_test` coverage for `viewport_height`, `viewport_width`, `viewport_stable_height`, `expand_viewport`, `show_alert`, `show_confirm`, `close_scan_qr_popup`, `on_content_safe_area_changed` (#201).
+
 ## [0.7.0] - 2026-05-13
 ### Changed
 - **MSRV:** minimum supported Rust version raised `1.94.1 → 1.95.0` (#198).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.7.0"
+version = "0.7.1"
 rust-version = "1.95.0"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION
## Summary

Release `0.7.1`. Patch bump — no MSRV change, no breaking API.

- `Cargo.toml`: package `version 0.7.0 → 0.7.1`.
- `CHANGELOG.md`: promote `[Unreleased]` to `## [0.7.1] - 2026-05-13` covering the once-into-js refactor (#203) and the test backfill (#201).

## After merge

Owner-only:
1. `cargo make tag` → `v0.7.1`.
2. `git push origin v0.7.1` → triggers `.github/workflows/release.yml` (CI → `cargo publish` → GitHub Release).

crates.io publication is irreversible; intentionally left as an explicit owner step.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green