### PR TITLE
206

### DIFF
--- a/demo/src/components/dev_menu.rs
+++ b/demo/src/components/dev_menu.rs
@@ -50,7 +50,7 @@ const BUTTON_IDS: &[(&str, Handler)] = &[
     }),
     // Checks home screen status asynchronously
     ("check-home-screen", |tg| {
-        let _ = tg.check_home_screen_status(|status| {
+        let _ = tg.check_home_screen_status_with_callback(|status| {
             // callback is fire-and-forget; log status
             info(&format!("home screen status: {}", status));
         });

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -1006,7 +1006,7 @@ mod tests {
         let status = Rc::new(RefCell::new(String::new()));
         let status_clone = Rc::clone(&status);
 
-        app.open_invoice("https://invoice", move |s| {
+        app.open_invoice_with_callback("https://invoice", move |s| {
             *status_clone.borrow_mut() = s;
         })
         .unwrap();
@@ -1053,7 +1053,7 @@ mod tests {
         let sent = Rc::new(Cell::new(false));
         let sent_clone = Rc::clone(&sent);
 
-        app.share_message("123", move |s| {
+        app.share_message_with_callback("123", move |s| {
             sent_clone.set(s);
         })
         .unwrap();
@@ -1143,7 +1143,8 @@ mod tests {
         let app = TelegramWebApp::instance().unwrap();
         let sent = std::rc::Rc::new(std::cell::Cell::new(false));
         let sent_ref = sent.clone();
-        app.request_chat(42, move |s| sent_ref.set(s)).unwrap();
+        app.request_chat_with_callback(42, move |s| sent_ref.set(s))
+            .unwrap();
 
         assert_eq!(
             Reflect::get(&webapp, &"req_chat_id".into())
@@ -1226,7 +1227,7 @@ mod tests {
         let status = Rc::new(RefCell::new(String::new()));
         let status_clone = Rc::clone(&status);
 
-        app.check_home_screen_status(move |s| {
+        app.check_home_screen_status_with_callback(move |s| {
             *status_clone.borrow_mut() = s;
         })
         .unwrap();
@@ -1333,7 +1334,7 @@ mod tests {
         let granted = Rc::new(Cell::new(false));
         let granted_clone = Rc::clone(&granted);
 
-        let res = app.request_write_access(move |g| {
+        let res = app.request_write_access_with_callback(move |g| {
             granted_clone.set(g);
         });
         assert!(res.is_ok());
@@ -1379,7 +1380,7 @@ mod tests {
             file_name: Some("data.bin"),
             mime_type: None
         };
-        app.download_file(params, move |id| {
+        app.download_file_with_callback(params, move |id| {
             *result_clone.borrow_mut() = id;
         })
         .unwrap();
@@ -1397,7 +1398,7 @@ mod tests {
     fn request_write_access_returns_error_when_missing() {
         let _webapp = setup_webapp();
         let app = TelegramWebApp::instance().unwrap();
-        let res = app.request_write_access(|_| {});
+        let res = app.request_write_access_with_callback(|_| {});
         assert!(res.is_err());
     }
     #[wasm_bindgen_test]
@@ -1411,7 +1412,7 @@ mod tests {
         let granted = Rc::new(Cell::new(true));
         let granted_clone = Rc::clone(&granted);
 
-        app.request_emoji_status_access(move |g| {
+        app.request_emoji_status_access_with_callback(move |g| {
             granted_clone.set(g);
         })
         .unwrap();
@@ -1437,7 +1438,7 @@ mod tests {
         let success = Rc::new(Cell::new(false));
         let success_clone = Rc::clone(&success);
 
-        app.set_emoji_status(&status.into(), move |s| {
+        app.set_emoji_status_with_callback(&status.into(), move |s| {
             success_clone.set(s);
         })
         .unwrap();
@@ -1461,7 +1462,7 @@ mod tests {
         let button = Rc::new(RefCell::new(String::new()));
         let button_clone = Rc::clone(&button);
 
-        app.show_popup(&JsValue::NULL, move |id| {
+        app.show_popup_with_callback(&JsValue::NULL, move |id| {
             *button_clone.borrow_mut() = id;
         })
         .unwrap();
@@ -1480,7 +1481,7 @@ mod tests {
         let text = Rc::new(RefCell::new(String::new()));
         let text_clone = Rc::clone(&text);
 
-        app.read_text_from_clipboard(move |t| {
+        app.read_text_from_clipboard_with_callback(move |t| {
             *text_clone.borrow_mut() = t;
         })
         .unwrap();
@@ -1501,7 +1502,7 @@ mod tests {
         let text = Rc::new(RefCell::new(String::new()));
         let text_clone = Rc::clone(&text);
 
-        app.show_scan_qr_popup("scan", move |value| {
+        app.show_scan_qr_popup_with_callback("scan", move |value| {
             *text_clone.borrow_mut() = value;
         })
         .unwrap();

--- a/src/webapp/core.rs
+++ b/src/webapp/core.rs
@@ -1,11 +1,35 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
-use js_sys::{Function, Object, Reflect};
+use js_sys::{Function, Object, Promise, Reflect};
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
+use wasm_bindgen_futures::JsFuture;
 use web_sys::window;
 
 use crate::{core::context::TelegramContext, webapp::TelegramWebApp};
+
+/// Build a `Promise` whose executor invokes `f` synchronously with the
+/// `resolve` and `reject` callables. If `f` returns `Err`, the promise is
+/// rejected with that value immediately. Used to wrap one-shot Telegram
+/// callbacks into async-friendly futures.
+pub(super) fn one_shot_promise<F>(f: F) -> Promise
+where
+    F: FnOnce(Function, Function) -> Result<(), JsValue>
+{
+    let mut executor = Some(f);
+    Promise::new(&mut |resolve, reject| {
+        let Some(invoke) = executor.take() else {
+            return;
+        };
+        if let Err(err) = invoke(resolve, reject.clone()) {
+            let _ = reject.call1(&JsValue::NULL, &err);
+        }
+    })
+}
+
+pub(super) async fn await_one_shot(promise: Promise) -> Result<JsValue, JsValue> {
+    JsFuture::from(promise).await
+}
 
 impl TelegramWebApp {
     /// Get instance of `Telegram.WebApp` or `None` if not present
@@ -97,24 +121,15 @@ impl TelegramWebApp {
 
     /// Call `WebApp.invokeCustomMethod(method, params, callback)`.
     ///
-    /// The JS callback is `(error, result)`; the wrapper translates it into
-    /// `Result<JsValue, JsValue>` for the Rust closure.
+    /// JS callback signature is `(error, result)`. The Rust callback receives a
+    /// `Result<JsValue, JsValue>` — `Ok(result)` when JS passes
+    /// `null`/`undefined` for error, `Err(err)` otherwise.
     ///
-    /// # Examples
-    /// ```no_run
-    /// # use js_sys::Object;
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// let params = Object::new();
-    /// app.invoke_custom_method("getRequestedContact", &params.into(), |outcome| {
-    ///     let _ = outcome;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// Prefer the `async` sibling [`Self::invoke_custom_method`] for new code.
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn invoke_custom_method<F>(
+    pub fn invoke_custom_method_with_callback<F>(
         &self,
         method: &str,
         params: &JsValue,
@@ -136,6 +151,57 @@ impl TelegramWebApp {
             .ok_or_else(|| JsValue::from_str("invokeCustomMethod is not a function"))?;
         func.call3(&self.inner, &method.into(), params, &cb)?;
         Ok(())
+    }
+
+    /// Async wrapper over `WebApp.invokeCustomMethod`.
+    ///
+    /// Resolves with the JS `result` value when Telegram returns a successful
+    /// response and rejects with the JS `error` value otherwise.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use js_sys::Object;
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+    /// let app = TelegramWebApp::try_instance()?;
+    /// let params = Object::new();
+    /// let result = app
+    ///     .invoke_custom_method("getRequestedContact", &params.into())
+    ///     .await?;
+    /// let _ = result;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if Telegram rejects the call or the underlying JS
+    /// invocation fails.
+    pub async fn invoke_custom_method(
+        &self,
+        method: &str,
+        params: &JsValue
+    ) -> Result<JsValue, JsValue> {
+        let webapp = self.inner.clone();
+        let method = method.to_owned();
+        let params = params.clone();
+        let promise = one_shot_promise(move |resolve, reject| {
+            let resolve_for_cb = resolve.clone();
+            let reject_for_cb = reject.clone();
+            let cb = Closure::once_into_js(move |err: JsValue, result: JsValue| {
+                if err.is_null() || err.is_undefined() {
+                    let _ = resolve_for_cb.call1(&JsValue::NULL, &result);
+                } else {
+                    let _ = reject_for_cb.call1(&JsValue::NULL, &err);
+                }
+            });
+            let f = Reflect::get(&webapp, &"invokeCustomMethod".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("invokeCustomMethod is not a function"))?;
+            func.call3(&webapp, &method.into(), &params, &cb)?;
+            Ok(())
+        });
+        await_one_shot(promise).await
     }
 
     // === Internal helper methods ===
@@ -193,7 +259,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
-    fn invoke_custom_method_passes_args_and_delivers_result() {
+    fn invoke_custom_method_with_callback_passes_args_and_delivers_result() {
         let webapp = setup_webapp();
         let invoke = Function::new_with_args(
             "method, params, cb",
@@ -206,7 +272,7 @@ mod tests {
         let cap = received.clone();
         let params = Object::new();
         let _ = Reflect::set(&params, &"x".into(), &"y".into());
-        app.invoke_custom_method("doStuff", &params.into(), move |out| {
+        app.invoke_custom_method_with_callback("doStuff", &params.into(), move |out| {
             *cap.borrow_mut() = Some(out.expect("ok"));
         })
         .expect("ok");
@@ -225,7 +291,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     #[allow(dead_code, clippy::unused_unit)]
-    fn invoke_custom_method_translates_error() {
+    fn invoke_custom_method_with_callback_translates_error() {
         let webapp = setup_webapp();
         let invoke = Function::new_with_args("_method, _params, cb", "cb('boom', null);");
         let _ = Reflect::set(&webapp, &"invokeCustomMethod".into(), &invoke);
@@ -233,12 +299,49 @@ mod tests {
         let app = TelegramWebApp::instance().expect("instance");
         let received = Rc::new(RefCell::new(None::<JsValue>));
         let cap = received.clone();
-        app.invoke_custom_method("doStuff", &JsValue::NULL, move |out| {
+        app.invoke_custom_method_with_callback("doStuff", &JsValue::NULL, move |out| {
             *cap.borrow_mut() = Some(out.expect_err("err"));
         })
         .expect("ok");
 
         let err = received.borrow().clone().expect("err");
+        assert_eq!(err.as_string().as_deref(), Some("boom"));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    async fn invoke_custom_method_async_resolves_with_result() {
+        let webapp = setup_webapp();
+        let invoke = Function::new_with_args(
+            "_method, _params, cb",
+            "setTimeout(() => cb(null, {ok: 7}), 0);"
+        );
+        let _ = Reflect::set(&webapp, &"invokeCustomMethod".into(), &invoke);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        let value = app
+            .invoke_custom_method("doStuff", &JsValue::NULL)
+            .await
+            .expect("resolved");
+        let ok = Reflect::get(&value, &"ok".into()).expect("ok field");
+        assert_eq!(ok.as_f64(), Some(7.0));
+    }
+
+    #[wasm_bindgen_test]
+    #[allow(dead_code, clippy::unused_unit)]
+    async fn invoke_custom_method_async_rejects_on_js_error() {
+        let webapp = setup_webapp();
+        let invoke = Function::new_with_args(
+            "_method, _params, cb",
+            "setTimeout(() => cb('boom', null), 0);"
+        );
+        let _ = Reflect::set(&webapp, &"invokeCustomMethod".into(), &invoke);
+
+        let app = TelegramWebApp::instance().expect("instance");
+        let err = app
+            .invoke_custom_method("doStuff", &JsValue::NULL)
+            .await
+            .expect_err("rejected");
         assert_eq!(err.as_string().as_deref(), Some("boom"));
     }
 }

--- a/src/webapp/dialogs.rs
+++ b/src/webapp/dialogs.rs
@@ -4,7 +4,10 @@
 use js_sys::{Function, Object, Reflect};
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 
-use crate::webapp::TelegramWebApp;
+use crate::webapp::{
+    TelegramWebApp,
+    core::{await_one_shot, one_shot_promise}
+};
 
 impl TelegramWebApp {
     /// Call `WebApp.showAlert(message)`.
@@ -15,11 +18,11 @@ impl TelegramWebApp {
         self.call1("showAlert", &msg.into())
     }
 
-    /// Call `WebApp.showConfirm(message, callback)`.
+    /// Callback variant of [`Self::show_confirm`].
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn show_confirm<F>(&self, msg: &str, on_confirm: F) -> Result<(), JsValue>
+    pub fn show_confirm_with_callback<F>(&self, msg: &str, on_confirm: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(bool)
     {
@@ -34,6 +37,29 @@ impl TelegramWebApp {
         Ok(())
     }
 
+    /// Async wrapper over `WebApp.showConfirm`. Resolves with the user's
+    /// boolean answer.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn show_confirm(&self, msg: &str) -> Result<bool, JsValue> {
+        let webapp = self.inner.clone();
+        let msg = msg.to_owned();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |v: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &v);
+            });
+            let f = Reflect::get(&webapp, &"showConfirm".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("showConfirm is not a function"))?;
+            func.call2(&webapp, &msg.into(), &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_bool().unwrap_or(false))
+    }
+
     /// Call `WebApp.showPopup(params, callback)`.
     ///
     /// # Examples
@@ -42,12 +68,13 @@ impl TelegramWebApp {
     /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
     /// # let app = TelegramWebApp::instance().unwrap();
     /// let params = Object::new();
-    /// app.show_popup(&params.into(), |id| {
+    /// app.show_popup_with_callback(&params.into(), |id| {
     ///     let _ = id;
     /// })
     /// .unwrap();
     /// ```
-    pub fn show_popup<F>(&self, params: &JsValue, callback: F) -> Result<(), JsValue>
+    /// Callback variant of [`Self::show_popup`].
+    pub fn show_popup_with_callback<F>(&self, params: &JsValue, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(String)
     {
@@ -60,6 +87,27 @@ impl TelegramWebApp {
         Ok(())
     }
 
+    /// Async wrapper over `WebApp.showPopup`. Resolves with the id of the
+    /// button the user pressed, or an empty string if the popup was dismissed.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn show_popup(&self, params: &JsValue) -> Result<String, JsValue> {
+        let webapp = self.inner.clone();
+        let params = params.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |id: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &id);
+            });
+            Reflect::get(&webapp, &"showPopup".into())?
+                .dyn_into::<Function>()?
+                .call2(&webapp, &params, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_string().unwrap_or_default())
+    }
+
     /// Call `WebApp.showScanQrPopup({ text }, callback)`.
     ///
     /// The text is shown above the scanner viewport. Pass an empty string to
@@ -69,12 +117,17 @@ impl TelegramWebApp {
     /// ```no_run
     /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
     /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.show_scan_qr_popup("Scan", |text| {
+    /// app.show_scan_qr_popup_with_callback("Scan", |text| {
     ///     let _ = text;
     /// })
     /// .unwrap();
     /// ```
-    pub fn show_scan_qr_popup<F>(&self, text: &str, callback: F) -> Result<(), JsValue>
+    /// Callback variant of [`Self::show_scan_qr_popup`].
+    pub fn show_scan_qr_popup_with_callback<F>(
+        &self,
+        text: &str,
+        callback: F
+    ) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(String)
     {
@@ -87,6 +140,29 @@ impl TelegramWebApp {
             .dyn_into::<Function>()?
             .call2(&self.inner, &params, &cb)?;
         Ok(())
+    }
+
+    /// Async wrapper over `WebApp.showScanQrPopup`. Resolves with the scanned
+    /// text. Pass an empty `text` to open the scanner without a caption.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn show_scan_qr_popup(&self, text: &str) -> Result<String, JsValue> {
+        let webapp = self.inner.clone();
+        let text = text.to_owned();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |value: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &value);
+            });
+            let params = Object::new();
+            Reflect::set(&params, &"text".into(), &text.into())?;
+            Reflect::get(&webapp, &"showScanQrPopup".into())?
+                .dyn_into::<Function>()?
+                .call2(&webapp, &params, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_string().unwrap_or_default())
     }
 
     /// Call `WebApp.closeScanQrPopup()`.
@@ -133,7 +209,8 @@ mod tests {
         let _ = Reflect::set(&webapp, &"showScanQrPopup".into(), &capture);
 
         let app = TelegramWebApp::instance().expect("instance");
-        app.show_scan_qr_popup("Scan", |_| {}).expect("ok");
+        app.show_scan_qr_popup_with_callback("Scan", |_| {})
+            .expect("ok");
 
         let params = Reflect::get(&webapp, &"captured_params".into()).expect("captured");
         assert!(!params.is_undefined(), "scan params must be an object");
@@ -172,7 +249,7 @@ mod tests {
         let app = TelegramWebApp::instance().expect("instance");
         let received = std::rc::Rc::new(std::cell::Cell::new(false));
         let received_ref = received.clone();
-        app.show_confirm("Proceed?", move |ok| received_ref.set(ok))
+        app.show_confirm_with_callback("Proceed?", move |ok| received_ref.set(ok))
             .expect("ok");
 
         assert_eq!(
@@ -217,7 +294,7 @@ mod tests {
         let app = TelegramWebApp::instance().expect("instance");
         let captured = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
         let captured_ref = captured.clone();
-        app.show_scan_qr_popup("", move |t| {
+        app.show_scan_qr_popup_with_callback("", move |t| {
             *captured_ref.borrow_mut() = t;
         })
         .expect("ok");

--- a/src/webapp/navigation.rs
+++ b/src/webapp/navigation.rs
@@ -5,7 +5,11 @@ use js_sys::{Function, Reflect};
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 
-use crate::webapp::{TelegramWebApp, types::OpenLinkOptions};
+use crate::webapp::{
+    TelegramWebApp,
+    core::{await_one_shot, one_shot_promise},
+    types::OpenLinkOptions
+};
 
 impl TelegramWebApp {
     /// Call `WebApp.openLink(url)`.
@@ -75,21 +79,11 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.shareMessage(msg_id, callback)`.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.share_message("id123", |sent| {
-    ///     let _ = sent;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// Callback variant of [`Self::share_message`].
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn share_message<F>(&self, msg_id: &str, callback: F) -> Result<(), JsValue>
+    pub fn share_message_with_callback<F>(&self, msg_id: &str, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(bool)
     {
@@ -102,6 +96,40 @@ impl TelegramWebApp {
             .ok_or_else(|| JsValue::from_str("shareMessage is not a function"))?;
         func.call2(&self.inner, &msg_id.into(), &cb)?;
         Ok(())
+    }
+
+    /// Async wrapper over `WebApp.shareMessage`. Resolves with `true` when the
+    /// prepared message was sent.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+    /// let app = TelegramWebApp::try_instance()?;
+    /// let sent: bool = app.share_message("id123").await?;
+    /// let _ = sent;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn share_message(&self, msg_id: &str) -> Result<bool, JsValue> {
+        let webapp = self.inner.clone();
+        let msg_id = msg_id.to_owned();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |v: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &v);
+            });
+            let f = Reflect::get(&webapp, &"shareMessage".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("shareMessage is not a function"))?;
+            func.call2(&webapp, &msg_id.into(), &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_bool().unwrap_or(false))
     }
 
     /// Call `WebApp.shareToStory(media_url, params)`.
@@ -158,28 +186,11 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.requestChat(req_id, callback)` (Bot API 9.6+).
-    ///
-    /// Opens a dialog that lets the user pick an existing chat matching the
-    /// prepared keyboard request previously saved via
-    /// `savePreparedKeyboardButton`. The callback receives `true` on
-    /// success and `false` when the user cancels or Telegram reports a
-    /// failure (`requestedChatFailed`).
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.request_chat(42, |sent| {
-    ///     let _ = sent;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// Callback variant of [`Self::request_chat`] (Bot API 9.6+).
     ///
     /// # Errors
-    /// Returns [`JsValue`] if the underlying JS call fails (including when the
-    /// running Telegram client predates Bot API 9.6).
-    pub fn request_chat<F>(&self, req_id: i32, callback: F) -> Result<(), JsValue>
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn request_chat_with_callback<F>(&self, req_id: i32, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(bool)
     {
@@ -192,6 +203,40 @@ impl TelegramWebApp {
             .ok_or_else(|| JsValue::from_str("requestChat is not a function"))?;
         func.call2(&self.inner, &req_id.into(), &cb)?;
         Ok(())
+    }
+
+    /// Async wrapper over `WebApp.requestChat` (Bot API 9.6+). Resolves with
+    /// `true` when the user picks a chat, `false` on cancel/failure.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
+    /// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+    /// let app = TelegramWebApp::try_instance()?;
+    /// let sent: bool = app.request_chat(42).await?;
+    /// let _ = sent;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails (including when the
+    /// running Telegram client predates Bot API 9.6).
+    pub async fn request_chat(&self, req_id: i32) -> Result<bool, JsValue> {
+        let webapp = self.inner.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |v: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &v);
+            });
+            let f = Reflect::get(&webapp, &"requestChat".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("requestChat is not a function"))?;
+            func.call2(&webapp, &req_id.into(), &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_bool().unwrap_or(false))
     }
 
     /// Call `WebApp.addToHomeScreen()` and return whether the prompt was shown.
@@ -211,18 +256,8 @@ impl TelegramWebApp {
         Ok(result.as_bool().unwrap_or(false))
     }
 
-    /// Call `WebApp.checkHomeScreenStatus(callback)`.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.check_home_screen_status(|status| {
-    ///     let _ = status;
-    /// })
-    /// .unwrap();
-    /// ```
-    pub fn check_home_screen_status<F>(&self, callback: F) -> Result<(), JsValue>
+    /// Callback variant of [`Self::check_home_screen_status`].
+    pub fn check_home_screen_status_with_callback<F>(&self, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(String)
     {
@@ -235,5 +270,27 @@ impl TelegramWebApp {
             .ok_or_else(|| JsValue::from_str("checkHomeScreenStatus is not a function"))?;
         func.call1(&self.inner, &cb)?;
         Ok(())
+    }
+
+    /// Async wrapper over `WebApp.checkHomeScreenStatus`. Resolves with the
+    /// status string Telegram returns (e.g. `"added"`, `"missed"`).
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn check_home_screen_status(&self) -> Result<String, JsValue> {
+        let webapp = self.inner.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |status: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &status);
+            });
+            let f = Reflect::get(&webapp, &"checkHomeScreenStatus".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("checkHomeScreenStatus is not a function"))?;
+            func.call1(&webapp, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_string().unwrap_or_default())
     }
 }

--- a/src/webapp/permissions.rs
+++ b/src/webapp/permissions.rs
@@ -5,24 +5,20 @@ use js_sys::{Function, Reflect};
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 
-use crate::{core::types::download_file_params::DownloadFileParams, webapp::TelegramWebApp};
+use crate::{
+    core::types::download_file_params::DownloadFileParams,
+    webapp::{
+        TelegramWebApp,
+        core::{await_one_shot, one_shot_promise}
+    }
+};
 
 impl TelegramWebApp {
-    /// Call `WebApp.requestWriteAccess(callback)`.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.request_write_access(|granted| {
-    ///     let _ = granted;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// Callback variant of [`Self::request_write_access`].
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn request_write_access<F>(&self, callback: F) -> Result<(), JsValue>
+    pub fn request_write_access_with_callback<F>(&self, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(bool)
     {
@@ -32,21 +28,46 @@ impl TelegramWebApp {
         self.call1("requestWriteAccess", &cb)
     }
 
-    /// Call `WebApp.requestEmojiStatusAccess(callback)`.
+    /// Async wrapper over `WebApp.requestWriteAccess`.
+    ///
+    /// Resolves with `true` when the user grants permission to receive
+    /// messages from the bot.
     ///
     /// # Examples
     /// ```no_run
     /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.request_emoji_status_access(|granted| {
-    ///     let _ = granted;
-    /// })
-    /// .unwrap();
+    /// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
+    /// let app = TelegramWebApp::try_instance()?;
+    /// let granted: bool = app.request_write_access().await?;
+    /// let _ = granted;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn request_emoji_status_access<F>(&self, callback: F) -> Result<(), JsValue>
+    pub async fn request_write_access(&self) -> Result<bool, JsValue> {
+        let webapp = self.inner.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |granted: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &granted);
+            });
+            let f = Reflect::get(&webapp, &"requestWriteAccess".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("requestWriteAccess is not a function"))?;
+            func.call1(&webapp, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_bool().unwrap_or(false))
+    }
+
+    /// Callback variant of [`Self::request_emoji_status_access`].
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn request_emoji_status_access_with_callback<F>(&self, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(bool)
     {
@@ -61,25 +82,36 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.setEmojiStatus(status, callback)`.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use js_sys::Object;
-    /// # use js_sys::Reflect;
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// let status = Object::new();
-    /// let _ = Reflect::set(&status, &"custom_emoji_id".into(), &"123".into());
-    /// app.set_emoji_status(&status.into(), |success| {
-    ///     let _ = success;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// Async wrapper over `WebApp.requestEmojiStatusAccess`.
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn set_emoji_status<F>(&self, status: &JsValue, callback: F) -> Result<(), JsValue>
+    pub async fn request_emoji_status_access(&self) -> Result<bool, JsValue> {
+        let webapp = self.inner.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |granted: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &granted);
+            });
+            let f = Reflect::get(&webapp, &"requestEmojiStatusAccess".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("requestEmojiStatusAccess is not a function"))?;
+            func.call1(&webapp, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_bool().unwrap_or(false))
+    }
+
+    /// Callback variant of [`Self::set_emoji_status`].
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn set_emoji_status_with_callback<F>(
+        &self,
+        status: &JsValue,
+        callback: F
+    ) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(bool)
     {
@@ -94,18 +126,30 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.openInvoice(url, callback)`.
+    /// Async wrapper over `WebApp.setEmojiStatus`.
     ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.open_invoice("https://invoice", |status| {
-    ///     let _ = status;
-    /// })
-    /// .unwrap();
-    /// ```
-    pub fn open_invoice<F>(&self, url: &str, callback: F) -> Result<(), JsValue>
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn set_emoji_status(&self, status: &JsValue) -> Result<bool, JsValue> {
+        let webapp = self.inner.clone();
+        let status = status.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |v: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &v);
+            });
+            let f = Reflect::get(&webapp, &"setEmojiStatus".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("setEmojiStatus is not a function"))?;
+            func.call2(&webapp, &status, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_bool().unwrap_or(false))
+    }
+
+    /// Callback variant of [`Self::open_invoice`].
+    pub fn open_invoice_with_callback<F>(&self, url: &str, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(String)
     {
@@ -118,28 +162,33 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.downloadFile(params, callback)`.
+    /// Async wrapper over `WebApp.openInvoice`. Resolves with the invoice
+    /// status string (`paid`, `cancelled`, `failed`, `pending`).
     ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::core::types::download_file_params::DownloadFileParams;
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// let params = DownloadFileParams {
-    ///     url:       "https://example.com/file",
-    ///     file_name: None,
-    ///     mime_type: None
-    /// };
-    /// app.download_file(params, |file_id| {
-    ///     let _ = file_id;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn open_invoice(&self, url: &str) -> Result<String, JsValue> {
+        let webapp = self.inner.clone();
+        let url = url.to_owned();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |status: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &status);
+            });
+            Reflect::get(&webapp, &"openInvoice".into())?
+                .dyn_into::<Function>()?
+                .call2(&webapp, &url.into(), &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_string().unwrap_or_default())
+    }
+
+    /// Callback variant of [`Self::download_file`].
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails or the parameters
     /// fail to serialize.
-    pub fn download_file<F>(
+    pub fn download_file_with_callback<F>(
         &self,
         params: DownloadFileParams<'_>,
         callback: F
@@ -158,21 +207,34 @@ impl TelegramWebApp {
         Ok(())
     }
 
-    /// Call `WebApp.readTextFromClipboard(callback)`.
+    /// Async wrapper over `WebApp.downloadFile`. Resolves with the file id
+    /// string that Telegram returns.
     ///
-    /// # Examples
-    /// ```no_run
-    /// # use telegram_webapp_sdk::webapp::TelegramWebApp;
-    /// # let app = TelegramWebApp::instance().unwrap();
-    /// app.read_text_from_clipboard(|text| {
-    ///     let _ = text;
-    /// })
-    /// .unwrap();
-    /// ```
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails or the parameters
+    /// fail to serialize.
+    pub async fn download_file(&self, params: DownloadFileParams<'_>) -> Result<String, JsValue> {
+        let js_params =
+            to_value(&params).map_err(|e| JsValue::from_str(&format!("serialize params: {e}")))?;
+        let webapp = self.inner.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |v: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &v);
+            });
+            Reflect::get(&webapp, &"downloadFile".into())?
+                .dyn_into::<Function>()?
+                .call2(&webapp, &js_params, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_string().unwrap_or_default())
+    }
+
+    /// Callback variant of [`Self::read_text_from_clipboard`].
     ///
     /// # Errors
     /// Returns [`JsValue`] if the underlying JS call fails.
-    pub fn read_text_from_clipboard<F>(&self, callback: F) -> Result<(), JsValue>
+    pub fn read_text_from_clipboard_with_callback<F>(&self, callback: F) -> Result<(), JsValue>
     where
         F: 'static + FnOnce(String)
     {
@@ -185,5 +247,26 @@ impl TelegramWebApp {
             .ok_or_else(|| JsValue::from_str("readTextFromClipboard is not a function"))?;
         func.call1(&self.inner, &cb)?;
         Ok(())
+    }
+
+    /// Async wrapper over `WebApp.readTextFromClipboard`.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub async fn read_text_from_clipboard(&self) -> Result<String, JsValue> {
+        let webapp = self.inner.clone();
+        let promise = one_shot_promise(move |resolve, _reject| {
+            let cb = Closure::once_into_js(move |text: JsValue| {
+                let _ = resolve.call1(&JsValue::NULL, &text);
+            });
+            let f = Reflect::get(&webapp, &"readTextFromClipboard".into())?;
+            let func = f
+                .dyn_ref::<Function>()
+                .ok_or_else(|| JsValue::from_str("readTextFromClipboard is not a function"))?;
+            func.call1(&webapp, &cb)?;
+            Ok(())
+        });
+        let value = await_one_shot(promise).await?;
+        Ok(value.as_string().unwrap_or_default())
     }
 }


### PR DESCRIPTION
## Summary

Add `async fn` siblings for every one-shot Telegram callback. Modern Rust mini-apps can now `await` Telegram's prompts the same way `@telegram-apps/sdk-react` does in TypeScript, while existing callback users migrate at their own pace.

### Mechanics

- New helper `webapp::core::one_shot_promise` builds a `js_sys::Promise` whose executor wraps a Telegram method with a `Closure::once_into_js`. Errors raised synchronously during executor setup reject the promise.
- New helper `webapp::core::await_one_shot` awaits the promise via `wasm_bindgen_futures::JsFuture`.
- Every existing callback method `foo(args, cb)` is renamed `foo_with_callback(args, cb)`; the bare `foo(args)` becomes an `async fn` returning the natural Rust type.

### Rename map (callback → async; bare name belongs to async)

| Module | Bare async | Renamed callback |
|---|---|---|
| `permissions.rs` | `request_write_access -> Result<bool>` | `request_write_access_with_callback` |
| `permissions.rs` | `request_emoji_status_access -> Result<bool>` | `request_emoji_status_access_with_callback` |
| `permissions.rs` | `set_emoji_status(&JsValue) -> Result<bool>` | `set_emoji_status_with_callback` |
| `permissions.rs` | `open_invoice(&str) -> Result<String>` | `open_invoice_with_callback` |
| `permissions.rs` | `download_file(params) -> Result<String>` | `download_file_with_callback` |
| `permissions.rs` | `read_text_from_clipboard -> Result<String>` | `read_text_from_clipboard_with_callback` |
| `navigation.rs` | `share_message(&str) -> Result<bool>` | `share_message_with_callback` |
| `navigation.rs` | `request_chat(i32) -> Result<bool>` | `request_chat_with_callback` |
| `navigation.rs` | `check_home_screen_status -> Result<String>` | `check_home_screen_status_with_callback` |
| `dialogs.rs` | `show_confirm(&str) -> Result<bool>` | `show_confirm_with_callback` |
| `dialogs.rs` | `show_popup(&JsValue) -> Result<String>` | `show_popup_with_callback` |
| `dialogs.rs` | `show_scan_qr_popup(&str) -> Result<String>` | `show_scan_qr_popup_with_callback` |
| `core.rs` | `invoke_custom_method(&str, &JsValue) -> Result<JsValue>` | `invoke_custom_method_with_callback` |

`invoke_custom_method` async additionally rejects the promise with the JS-side error value when Telegram returns one (the callback variant continues to deliver `Result<JsValue, JsValue>`).

### Tests

- Existing `wasm_bindgen_test`s renamed to call the `_with_callback` variants (behaviour assertions unchanged).
- New `async` `wasm_bindgen_test`s for `invoke_custom_method` covering both the resolve and the reject paths.
- Demo crate updated for the rename (`tg.check_home_screen_status_with_callback`).

### SemVer

Method renames are breaking → **0.8.0** minor bump in a follow-up release PR.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native)
- [x] `cargo test --no-run --lib --all-features -p telegram-webapp-sdk` (wasm tests compile)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green