### PR TITLE
208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-13
+### Added
+- `async fn` siblings for every one-shot Telegram callback, so prod code can `await` Telegram prompts the same way `@telegram-apps/sdk-react` does in TypeScript: `request_write_access`, `request_emoji_status_access`, `set_emoji_status`, `open_invoice`, `download_file`, `read_text_from_clipboard`, `share_message`, `request_chat`, `check_home_screen_status`, `show_confirm`, `show_popup`, `show_scan_qr_popup`, `invoke_custom_method`. `invoke_custom_method` rejects the future on JS-side errors (#207).
+
+### Changed
+- **BREAKING:** every existing callback method renamed to `*_with_callback` so the bare name can host the new async sibling. Migration: append `_with_callback` to existing call sites, or switch to `.await`.
+
 ## [0.7.1] - 2026-05-13
 ### Changed
 - One-shot Telegram callbacks now use `Closure::once_into_js`, so the boxed closure is deallocated after JS invokes it instead of leaking per call. Affects `request_write_access`, `request_emoji_status_access`, `set_emoji_status`, `open_invoice`, `download_file`, `read_text_from_clipboard`, `share_message`, `request_chat`, `check_home_screen_status`, `show_confirm`, `show_popup`, `show_scan_qr_popup`, `invoke_custom_method`. Callback bounds widened `Fn → FnOnce` (strict expansion — existing call sites unaffected) (#203).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.7.1"
+version = "0.8.0"
 rust-version = "1.95.0"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION
## Summary

Release `0.8.0`. Minor bump because #207 renamed every callback method to free up the bare name for the new `async fn` siblings.

- `Cargo.toml`: package `version 0.7.1 → 0.8.0`.
- `CHANGELOG.md`: promote `[Unreleased]` to `## [0.8.0] - 2026-05-13` covering the async API (#207).

## After merge

Owner-only:
1. `cargo make tag` → `v0.8.0`.
2. `git push origin v0.8.0` → `release.yml`.

crates.io publication is irreversible; intentionally left as an explicit owner step.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (139/139)
- [ ] CI green