### PR TITLE
210

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5135,6 +5135,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "reqwest 0.13.3",
+ "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,16 @@ optional = true
 default-features = false
 features = ["csr"]
 
+[dependencies.send_wrapper]
+version = "0.6"
+optional = true
+
 [features]
 default = []
 
 macros = ["dep:inventory"]
 yew = ["dep:yew"]
-leptos = ["dep:leptos"]
+leptos = ["dep:leptos", "dep:send_wrapper"]
 mock = ["dep:urlencoding"]
 full = ["macros", "yew", "leptos", "mock"]
 

--- a/src/core/types/theme_params.rs
+++ b/src/core/types/theme_params.rs
@@ -25,7 +25,7 @@ use crate::logger::warn;
 /// theme.apply_to_root()?;
 /// # Ok::<(), JsValue>(())
 /// ```
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct TelegramThemeParams {
     /// Primary background color (`--tg-theme-bg-color`).

--- a/src/leptos.rs
+++ b/src/leptos.rs
@@ -2,8 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 pub mod bottom_button;
+pub mod safe_area;
+pub mod theme;
+pub mod viewport;
+
 pub use bottom_button::BottomButton;
 use leptos::prelude::provide_context;
+pub use safe_area::{SafeAreaState, use_safe_area};
+pub use theme::{ThemeState, use_theme};
+pub use viewport::{ViewportState, use_viewport};
 use wasm_bindgen::JsValue;
 
 use crate::core::{context::TelegramContext, safe_context::get_context};

--- a/src/leptos/safe_area.rs
+++ b/src/leptos/safe_area.rs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use leptos::prelude::*;
+use send_wrapper::SendWrapper;
+
+use crate::webapp::{EventHandle, SafeAreaInset, TelegramWebApp};
+
+/// Snapshot of `Telegram.WebApp` safe-area insets.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct SafeAreaState {
+    /// `WebApp.safeAreaInset`.
+    pub area:    Option<SafeAreaInset>,
+    /// `WebApp.contentSafeAreaInset`.
+    pub content: Option<SafeAreaInset>
+}
+
+impl SafeAreaState {
+    fn snapshot(app: Option<&TelegramWebApp>) -> Self {
+        match app {
+            Some(app) => Self {
+                area:    app.safe_area_inset(),
+                content: app.content_safe_area_inset()
+            },
+            None => Self::default()
+        }
+    }
+}
+
+/// Leptos reactive hook over the safe-area insets.
+///
+/// Updates on both `safeAreaChanged` and `contentSafeAreaChanged`. The
+/// subscriptions are removed on scope disposal.
+///
+/// # Examples
+/// ```no_run
+/// use leptos::prelude::*;
+/// use telegram_webapp_sdk::leptos::use_safe_area;
+///
+/// #[component]
+/// fn TopPadding() -> impl IntoView {
+///     let safe = use_safe_area();
+///     view! { <div>{ move || safe.get().area.map(|i| i.top).unwrap_or(0.0) }</div> }
+/// }
+/// ```
+pub fn use_safe_area() -> ReadSignal<SafeAreaState> {
+    let app = TelegramWebApp::instance();
+    let signal = RwSignal::new(SafeAreaState::snapshot(app.as_ref()));
+
+    if let Some(app) = app {
+        let writer = signal;
+
+        let app_area = app.clone();
+        let area_handle: Option<EventHandle<dyn FnMut()>> = app
+            .on_safe_area_changed(move || {
+                writer.set(SafeAreaState::snapshot(Some(&app_area)));
+            })
+            .ok();
+
+        let app_content = app.clone();
+        let content_handle: Option<EventHandle<dyn FnMut()>> = app
+            .on_content_safe_area_changed(move || {
+                writer.set(SafeAreaState::snapshot(Some(&app_content)));
+            })
+            .ok();
+
+        let wrapped = SendWrapper::new((area_handle, content_handle));
+        on_cleanup(move || {
+            drop(wrapped);
+        });
+    }
+
+    signal.read_only()
+}

--- a/src/leptos/theme.rs
+++ b/src/leptos/theme.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use leptos::prelude::*;
+use send_wrapper::SendWrapper;
+
+use crate::{
+    api::theme::get_theme_params, core::types::theme_params::TelegramThemeParams,
+    webapp::TelegramWebApp
+};
+
+/// Snapshot of `Telegram.WebApp` theme state.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ThemeState {
+    /// `"light"` or `"dark"`.
+    pub color_scheme: Option<String>,
+    /// Parsed theme palette.
+    pub params:       TelegramThemeParams
+}
+
+impl ThemeState {
+    fn snapshot(app: Option<&TelegramWebApp>) -> Self {
+        let color_scheme = app.and_then(|a| a.color_scheme());
+        let params = get_theme_params().unwrap_or_default();
+        Self {
+            color_scheme,
+            params
+        }
+    }
+}
+
+/// Leptos reactive hook over `Telegram.WebApp` theme state.
+///
+/// Updates on `themeChanged`. The subscription is removed on scope disposal.
+///
+/// # Examples
+/// ```no_run
+/// use leptos::prelude::*;
+/// use telegram_webapp_sdk::leptos::use_theme;
+///
+/// #[component]
+/// fn ThemeBadge() -> impl IntoView {
+///     let theme = use_theme();
+///     view! { <span>{ move || theme.get().color_scheme.unwrap_or_default() }</span> }
+/// }
+/// ```
+pub fn use_theme() -> ReadSignal<ThemeState> {
+    let app = TelegramWebApp::instance();
+    let signal = RwSignal::new(ThemeState::snapshot(app.as_ref()));
+
+    if let Some(app) = app {
+        let app_for_handler = app.clone();
+        let writer = signal;
+        if let Ok(handle) = app.on_theme_changed(move || {
+            writer.set(ThemeState::snapshot(Some(&app_for_handler)));
+        }) {
+            let wrapped = SendWrapper::new(handle);
+            on_cleanup(move || {
+                drop(wrapped);
+            });
+        }
+    }
+
+    signal.read_only()
+}

--- a/src/leptos/viewport.rs
+++ b/src/leptos/viewport.rs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use leptos::prelude::*;
+use send_wrapper::SendWrapper;
+
+use crate::webapp::TelegramWebApp;
+
+/// Snapshot of `Telegram.WebApp`'s viewport-related properties.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ViewportState {
+    /// Current visible viewport height in CSS pixels.
+    pub height:        f64,
+    /// Stable viewport height (does not change while the user pulls the chat).
+    pub stable_height: f64,
+    /// Whether the mini app is currently expanded.
+    pub is_expanded:   bool
+}
+
+impl ViewportState {
+    fn snapshot(app: Option<&TelegramWebApp>) -> Self {
+        match app {
+            Some(app) => Self {
+                height:        app.viewport_height().unwrap_or(0.0),
+                stable_height: app.viewport_stable_height().unwrap_or(0.0),
+                is_expanded:   app.is_expanded()
+            },
+            None => Self::default()
+        }
+    }
+}
+
+/// Leptos reactive hook over `Telegram.WebApp` viewport state.
+///
+/// The returned [`ReadSignal`] starts with a snapshot taken at mount time and
+/// updates whenever Telegram fires `viewportChanged`. The underlying event
+/// subscription is automatically removed when the owning Leptos scope is
+/// disposed.
+///
+/// # Examples
+/// ```no_run
+/// use leptos::prelude::*;
+/// use telegram_webapp_sdk::leptos::use_viewport;
+///
+/// #[component]
+/// fn ViewportBadge() -> impl IntoView {
+///     let viewport = use_viewport();
+///     view! { <span>{ move || viewport.get().height }</span> }
+/// }
+/// ```
+pub fn use_viewport() -> ReadSignal<ViewportState> {
+    let app = TelegramWebApp::instance();
+    let signal = RwSignal::new(ViewportState::snapshot(app.as_ref()));
+
+    if let Some(app) = app {
+        let app_for_handler = app.clone();
+        let writer = signal;
+        if let Ok(handle) = app.on_viewport_changed(move || {
+            writer.set(ViewportState::snapshot(Some(&app_for_handler)));
+        }) {
+            let wrapped = SendWrapper::new(handle);
+            on_cleanup(move || {
+                drop(wrapped);
+            });
+        }
+    }
+
+    signal.read_only()
+}


### PR DESCRIPTION
## Summary

Add the three reactive primitives a Telegram Mini App actually needs day-to-day, on par with `@telegram-apps/sdk-react`'s `useViewport`/`useThemeParams`/`useMiniApp`:

- `leptos::use_viewport() -> ReadSignal<ViewportState { height, stable_height, is_expanded }>`
- `leptos::use_theme() -> ReadSignal<ThemeState { color_scheme, params: TelegramThemeParams }>`
- `leptos::use_safe_area() -> ReadSignal<SafeAreaState { area, content }>`

Each hook takes an initial snapshot, subscribes to the corresponding Telegram event (`viewportChanged`, `themeChanged`, `safeAreaChanged` + `contentSafeAreaChanged`) via the existing `on_*_changed` API, and registers an `on_cleanup` that drops the returned `EventHandle` — the `Drop` impl on `EventHandle` deregisters the JS callback for us.

### Implementation notes

- Leptos 0.7+ requires the `on_cleanup` closure to be `Send + Sync + 'static`, but `EventHandle` wraps a `js_sys::Object` which is `!Send`. Wrapping in `send_wrapper::SendWrapper` is the idiomatic single-threaded-WASM fix (the wrapper panics on cross-thread access; in the browser there's only one thread).
- `send_wrapper` is gated behind the `leptos` feature.
- `TelegramThemeParams` now derives `PartialEq` + `Eq` so `ThemeState` can derive `PartialEq` (required for Leptos signal change detection).

## Test plan

- [x] `cargo check -p telegram-webapp-sdk --features leptos`
- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (142/142)
- [ ] CI green