### PR TITLE
212

### DIFF
--- a/src/yew.rs
+++ b/src/yew.rs
@@ -9,7 +9,14 @@ use yew::prelude::{hook, use_effect, use_state};
 use crate::core::{context::TelegramContext, safe_context::get_context};
 
 pub mod bottom_button;
+pub mod safe_area;
+pub mod theme;
+pub mod viewport;
+
 pub use bottom_button::BottomButton;
+pub use safe_area::{SafeAreaState, use_safe_area};
+pub use theme::{ThemeState, use_theme};
+pub use viewport::{ViewportState, use_viewport};
 
 type ClosureCell = Rc<RefCell<Option<Closure<dyn FnMut()>>>>;
 

--- a/src/yew/safe_area.rs
+++ b/src/yew/safe_area.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::{cell::RefCell, rc::Rc};
+
+use yew::prelude::{hook, use_effect_with, use_state};
+
+use crate::webapp::{EventHandle, SafeAreaInset, TelegramWebApp};
+
+type HandleList = Rc<RefCell<Vec<EventHandle<dyn FnMut()>>>>;
+
+/// Snapshot of `Telegram.WebApp` safe-area insets.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct SafeAreaState {
+    /// `WebApp.safeAreaInset`.
+    pub area:    Option<SafeAreaInset>,
+    /// `WebApp.contentSafeAreaInset`.
+    pub content: Option<SafeAreaInset>
+}
+
+impl SafeAreaState {
+    fn snapshot(app: Option<&TelegramWebApp>) -> Self {
+        match app {
+            Some(app) => Self {
+                area:    app.safe_area_inset(),
+                content: app.content_safe_area_inset()
+            },
+            None => Self::default()
+        }
+    }
+}
+
+/// Yew reactive hook over the safe-area insets.
+///
+/// Updates on both `safeAreaChanged` and `contentSafeAreaChanged`. The
+/// subscriptions are removed on unmount.
+#[hook]
+pub fn use_safe_area() -> SafeAreaState {
+    let state = use_state(|| SafeAreaState::snapshot(TelegramWebApp::instance().as_ref()));
+
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let stash: HandleList = Rc::new(RefCell::new(Vec::new()));
+            if let Some(app) = TelegramWebApp::instance() {
+                {
+                    let app_for_handler = app.clone();
+                    let state_for_handler = state.clone();
+                    if let Ok(handle) = app.on_safe_area_changed(move || {
+                        state_for_handler.set(SafeAreaState::snapshot(Some(&app_for_handler)));
+                    }) {
+                        stash.borrow_mut().push(handle);
+                    }
+                }
+                {
+                    let app_for_handler = app.clone();
+                    let state_for_handler = state.clone();
+                    if let Ok(handle) = app.on_content_safe_area_changed(move || {
+                        state_for_handler.set(SafeAreaState::snapshot(Some(&app_for_handler)));
+                    }) {
+                        stash.borrow_mut().push(handle);
+                    }
+                }
+            }
+            move || {
+                stash.borrow_mut().clear();
+            }
+        });
+    }
+
+    (*state).clone()
+}

--- a/src/yew/theme.rs
+++ b/src/yew/theme.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::{cell::RefCell, rc::Rc};
+
+use yew::prelude::{hook, use_effect_with, use_state};
+
+use crate::{
+    api::theme::get_theme_params,
+    core::types::theme_params::TelegramThemeParams,
+    webapp::{EventHandle, TelegramWebApp}
+};
+
+type HandleSlot = Rc<RefCell<Option<EventHandle<dyn FnMut()>>>>;
+
+/// Snapshot of `Telegram.WebApp` theme state.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ThemeState {
+    /// `"light"` or `"dark"`.
+    pub color_scheme: Option<String>,
+    /// Parsed theme palette.
+    pub params:       TelegramThemeParams
+}
+
+impl ThemeState {
+    fn snapshot(app: Option<&TelegramWebApp>) -> Self {
+        let color_scheme = app.and_then(|a| a.color_scheme());
+        let params = get_theme_params().unwrap_or_default();
+        Self {
+            color_scheme,
+            params
+        }
+    }
+}
+
+/// Yew reactive hook over `Telegram.WebApp` theme state.
+///
+/// Updates on `themeChanged`. The subscription is removed on unmount.
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::yew::use_theme;
+/// use yew::prelude::*;
+///
+/// #[component]
+/// fn ThemeBadge() -> Html {
+///     let theme = use_theme();
+///     html! { <span>{ theme.color_scheme.clone().unwrap_or_default() }</span> }
+/// }
+/// ```
+#[hook]
+pub fn use_theme() -> ThemeState {
+    let state = use_state(|| ThemeState::snapshot(TelegramWebApp::instance().as_ref()));
+
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let stash: HandleSlot = Rc::new(RefCell::new(None));
+            if let Some(app) = TelegramWebApp::instance() {
+                let app_for_handler = app.clone();
+                let state_for_handler = state.clone();
+                if let Ok(handle) = app.on_theme_changed(move || {
+                    state_for_handler.set(ThemeState::snapshot(Some(&app_for_handler)));
+                }) {
+                    *stash.borrow_mut() = Some(handle);
+                }
+            }
+            move || {
+                stash.borrow_mut().take();
+            }
+        });
+    }
+
+    (*state).clone()
+}

--- a/src/yew/viewport.rs
+++ b/src/yew/viewport.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::{cell::RefCell, rc::Rc};
+
+use yew::prelude::{hook, use_effect_with, use_state};
+
+use crate::webapp::{EventHandle, TelegramWebApp};
+
+type HandleSlot = Rc<RefCell<Option<EventHandle<dyn FnMut()>>>>;
+
+/// Snapshot of `Telegram.WebApp`'s viewport-related properties.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ViewportState {
+    /// Current visible viewport height in CSS pixels.
+    pub height:        f64,
+    /// Stable viewport height (does not change while the user pulls the chat).
+    pub stable_height: f64,
+    /// Whether the mini app is currently expanded.
+    pub is_expanded:   bool
+}
+
+impl ViewportState {
+    fn snapshot(app: Option<&TelegramWebApp>) -> Self {
+        match app {
+            Some(app) => Self {
+                height:        app.viewport_height().unwrap_or(0.0),
+                stable_height: app.viewport_stable_height().unwrap_or(0.0),
+                is_expanded:   app.is_expanded()
+            },
+            None => Self::default()
+        }
+    }
+}
+
+/// Yew reactive hook over `Telegram.WebApp` viewport state.
+///
+/// Starts with an initial snapshot and re-renders the component whenever
+/// Telegram fires `viewportChanged`. The subscription is automatically
+/// removed when the component unmounts.
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::yew::use_viewport;
+/// use yew::prelude::*;
+///
+/// #[component]
+/// fn ViewportBadge() -> Html {
+///     let viewport = use_viewport();
+///     html! { <span>{ viewport.height }</span> }
+/// }
+/// ```
+#[hook]
+pub fn use_viewport() -> ViewportState {
+    let state = use_state(|| ViewportState::snapshot(TelegramWebApp::instance().as_ref()));
+
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let stash: HandleSlot = Rc::new(RefCell::new(None));
+            if let Some(app) = TelegramWebApp::instance() {
+                let app_for_handler = app.clone();
+                let state_for_handler = state.clone();
+                if let Ok(handle) = app.on_viewport_changed(move || {
+                    state_for_handler.set(ViewportState::snapshot(Some(&app_for_handler)));
+                }) {
+                    *stash.borrow_mut() = Some(handle);
+                }
+            }
+            move || {
+                stash.borrow_mut().take();
+            }
+        });
+    }
+
+    (*state).clone()
+}


### PR DESCRIPTION
## Summary

Yew counterpart of #211. Three `#[hook]`s that snapshot Telegram state on first render and re-render the component when Telegram fires the matching `*_changed` event. The subscription lives for the component lifetime via `use_effect_with((), …)` and is dropped on unmount.

- `yew::use_viewport() -> ViewportState`
- `yew::use_theme() -> ThemeState`
- `yew::use_safe_area() -> SafeAreaState`

Each `*State` struct mirrors the Leptos one from #211, so a future shared types refactor can collapse them.

### Implementation notes

- Yew is single-threaded in the browser, so the implementation uses plain `Rc<RefCell<EventHandle<dyn FnMut()>>>` — no `SendWrapper` required (unlike Leptos 0.7+).
- Type aliases `HandleSlot` / `HandleList` keep `clippy::type_complexity` quiet.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (145/145)
- [ ] CI green