### PR TITLE
214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-13
+### Added
+- **Leptos (`leptos` feature):** reactive hooks `use_viewport`, `use_theme`, `use_safe_area` returning `ReadSignal<*State>`. State structs `ViewportState`, `ThemeState`, `SafeAreaState`. Subscription auto-cleans on scope disposal (#211).
+- **Yew (`yew` feature):** matching `#[hook]`s `use_viewport`, `use_theme`, `use_safe_area` returning `*State` directly. Subscription cleared on unmount (#213).
+
+### Changed
+- New optional dependency `send_wrapper` gated behind the `leptos` feature (required by Leptos 0.7+'s `Send + Sync` bound on `on_cleanup`).
+- `TelegramThemeParams` now derives `PartialEq` + `Eq` so reactive state structs can derive `PartialEq` for change detection.
+
 ## [0.8.0] - 2026-05-13
 ### Added
 - `async fn` siblings for every one-shot Telegram callback, so prod code can `await` Telegram prompts the same way `@telegram-apps/sdk-react` does in TypeScript: `request_write_access`, `request_emoji_status_access`, `set_emoji_status`, `open_invoice`, `download_file`, `read_text_from_clipboard`, `share_message`, `request_chat`, `check_home_screen_status`, `show_confirm`, `show_popup`, `show_scan_qr_popup`, `invoke_custom_method`. `invoke_custom_method` rejects the future on JS-side errors (#207).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.8.0"
+version = "0.9.0"
 rust-version = "1.95.0"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION
## Summary

Release `0.9.0`. Minor bump — additive Leptos and Yew reactive hooks (#211, #213) on top of 0.8.0.

- `Cargo.toml`: package `version 0.8.0 → 0.9.0`.
- `CHANGELOG.md`: promote `[Unreleased]` to `## [0.9.0] - 2026-05-13` covering the new `use_viewport`/`use_theme`/`use_safe_area` hooks for both frameworks plus the `send_wrapper` dep (gated behind `leptos`) and the `PartialEq` derive on `TelegramThemeParams`.

## After merge

Owner-only:
1. `cargo make tag` → `v0.9.0`.
2. `git push origin v0.9.0` → `release.yml` (CI → `cargo publish` → GitHub Release).

crates.io publication is irreversible; intentionally left as an explicit owner step.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (145/145)
- [ ] CI green