### PR TITLE
216

### DIFF
--- a/src/leptos.rs
+++ b/src/leptos.rs
@@ -1,14 +1,18 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+pub mod back_button;
 pub mod bottom_button;
 pub mod safe_area;
+pub mod settings_button;
 pub mod theme;
 pub mod viewport;
 
+pub use back_button::BackButton;
 pub use bottom_button::BottomButton;
 use leptos::prelude::provide_context;
 pub use safe_area::{SafeAreaState, use_safe_area};
+pub use settings_button::SettingsButton;
 pub use theme::{ThemeState, use_theme};
 pub use viewport::{ViewportState, use_viewport};
 use wasm_bindgen::JsValue;

--- a/src/leptos/back_button.rs
+++ b/src/leptos/back_button.rs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::cell::RefCell;
+
+use leptos::prelude::*;
+
+use crate::{
+    logger,
+    webapp::{EventHandle, TelegramWebApp}
+};
+
+thread_local! {
+    static BACK_BUTTON_HANDLE: RefCell<Option<EventHandle<dyn FnMut()>>> =
+        const { RefCell::new(None) };
+}
+
+/// Leptos component for the native back button.
+///
+/// Mirrors the React SDK's `BackButton` ergonomics. Drives `WebApp.BackButton`:
+/// shows/hides it based on the `visible` signal, registers the optional click
+/// callback, and cleans both up on unmount.
+///
+/// # Examples
+/// ```no_run
+/// use leptos::prelude::*;
+/// use telegram_webapp_sdk::leptos::BackButton;
+///
+/// #[component]
+/// fn App() -> impl IntoView {
+///     let visible = RwSignal::new(true);
+///     view! {
+///         <BackButton
+///             visible=visible
+///             on_click=move || { web_sys::console::log_1(&"back".into()); }
+///         />
+///     }
+/// }
+/// ```
+#[component]
+pub fn BackButton<F>(
+    #[prop(into)] visible: Signal<bool>,
+    #[prop(optional)] on_click: Option<F>
+) -> impl IntoView
+where
+    F: Fn() + Clone + 'static
+{
+    Effect::new(move |_| {
+        if let Some(app) = TelegramWebApp::instance() {
+            let result = if visible.get() {
+                app.show_back_button()
+            } else {
+                app.hide_back_button()
+            };
+            if let Err(err) = result {
+                logger::error(&format!("BackButton visibility toggle failed: {err:?}"));
+            }
+        }
+    });
+
+    if let Some(cb) = on_click
+        && let Some(app) = TelegramWebApp::instance()
+    {
+        match app.set_back_button_callback(cb) {
+            Ok(handle) => BACK_BUTTON_HANDLE.with(|c| {
+                *c.borrow_mut() = Some(handle);
+            }),
+            Err(err) => logger::error(&format!("set_back_button_callback failed: {err:?}"))
+        }
+    }
+
+    on_cleanup(move || {
+        if let Some(app) = TelegramWebApp::instance() {
+            BACK_BUTTON_HANDLE.with(|c| {
+                if let Some(handle) = c.borrow_mut().take()
+                    && let Err(err) = app.remove_back_button_callback(handle)
+                {
+                    logger::error(&format!("remove_back_button_callback failed: {err:?}"));
+                }
+            });
+            if let Err(err) = app.hide_back_button() {
+                logger::error(&format!("hide_back_button failed: {err:?}"));
+            }
+        }
+    });
+
+    View::new(())
+}

--- a/src/leptos/settings_button.rs
+++ b/src/leptos/settings_button.rs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::cell::RefCell;
+
+use leptos::prelude::*;
+
+use crate::{
+    logger,
+    webapp::{EventHandle, TelegramWebApp}
+};
+
+thread_local! {
+    static SETTINGS_BUTTON_HANDLE: RefCell<Option<EventHandle<dyn FnMut()>>> =
+        const { RefCell::new(None) };
+}
+
+/// Leptos component for the native settings button.
+///
+/// Drives `WebApp.SettingsButton`: shows/hides it based on the `visible`
+/// signal, registers the optional click callback, and cleans both up on
+/// unmount.
+///
+/// # Examples
+/// ```no_run
+/// use leptos::prelude::*;
+/// use telegram_webapp_sdk::leptos::SettingsButton;
+///
+/// #[component]
+/// fn App() -> impl IntoView {
+///     let visible = RwSignal::new(true);
+///     view! {
+///         <SettingsButton
+///             visible=visible
+///             on_click=move || { web_sys::console::log_1(&"settings".into()); }
+///         />
+///     }
+/// }
+/// ```
+#[component]
+pub fn SettingsButton<F>(
+    #[prop(into)] visible: Signal<bool>,
+    #[prop(optional)] on_click: Option<F>
+) -> impl IntoView
+where
+    F: Fn() + Clone + 'static
+{
+    Effect::new(move |_| {
+        if let Some(app) = TelegramWebApp::instance() {
+            let result = if visible.get() {
+                app.show_settings_button()
+            } else {
+                app.hide_settings_button()
+            };
+            if let Err(err) = result {
+                logger::error(&format!("SettingsButton visibility toggle failed: {err:?}"));
+            }
+        }
+    });
+
+    if let Some(cb) = on_click
+        && let Some(app) = TelegramWebApp::instance()
+    {
+        match app.set_settings_button_callback(cb) {
+            Ok(handle) => SETTINGS_BUTTON_HANDLE.with(|c| {
+                *c.borrow_mut() = Some(handle);
+            }),
+            Err(err) => logger::error(&format!("set_settings_button_callback failed: {err:?}"))
+        }
+    }
+
+    on_cleanup(move || {
+        if let Some(app) = TelegramWebApp::instance() {
+            SETTINGS_BUTTON_HANDLE.with(|c| {
+                if let Some(handle) = c.borrow_mut().take()
+                    && let Err(err) = app.remove_settings_button_callback(handle)
+                {
+                    logger::error(&format!("remove_settings_button_callback failed: {err:?}"));
+                }
+            });
+            if let Err(err) = app.hide_settings_button() {
+                logger::error(&format!("hide_settings_button failed: {err:?}"));
+            }
+        }
+    });
+
+    View::new(())
+}

--- a/src/webapp/buttons.rs
+++ b/src/webapp/buttons.rs
@@ -515,6 +515,69 @@ impl TelegramWebApp {
             .unwrap_or(false)
     }
 
+    // === Settings button operations ===
+
+    /// Show the native settings button.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn show_settings_button(&self) -> Result<(), JsValue> {
+        self.call_nested0("SettingsButton", "show")
+    }
+
+    /// Hide the native settings button.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn hide_settings_button(&self) -> Result<(), JsValue> {
+        self.call_nested0("SettingsButton", "hide")
+    }
+
+    /// Registers a callback for the native settings button.
+    ///
+    /// Returns an [`EventHandle`] that can be passed to
+    /// [`remove_settings_button_callback`](Self::remove_settings_button_callback).
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn set_settings_button_callback<F>(
+        &self,
+        callback: F
+    ) -> Result<EventHandle<dyn FnMut()>, JsValue>
+    where
+        F: 'static + Fn()
+    {
+        let button_val = Reflect::get(&self.inner, &"SettingsButton".into())?;
+        let button = button_val.dyn_into::<Object>()?;
+        let cb = Closure::<dyn FnMut()>::new(callback);
+        let f = Reflect::get(&button, &"onClick".into())?;
+        let func = f
+            .dyn_ref::<Function>()
+            .ok_or_else(|| JsValue::from_str("onClick is not a function"))?;
+        func.call1(&button, cb.as_ref().unchecked_ref())?;
+        Ok(EventHandle::new(button, "offClick", None, cb))
+    }
+
+    /// Remove previously set settings button callback.
+    ///
+    /// # Errors
+    /// Returns [`JsValue`] if the underlying JS call fails.
+    pub fn remove_settings_button_callback(
+        &self,
+        handle: EventHandle<dyn FnMut()>
+    ) -> Result<(), JsValue> {
+        handle.unregister()
+    }
+
+    /// Returns whether the native settings button is visible.
+    pub fn is_settings_button_visible(&self) -> bool {
+        Reflect::get(&self.inner, &"SettingsButton".into())
+            .ok()
+            .and_then(|bb| Reflect::get(&bb, &"isVisible".into()).ok())
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
     // === Legacy aliases for main button ===
 
     /// Legacy alias for [`Self::show_bottom_button`] with

--- a/src/yew.rs
+++ b/src/yew.rs
@@ -8,13 +8,17 @@ use yew::prelude::{hook, use_effect, use_state};
 
 use crate::core::{context::TelegramContext, safe_context::get_context};
 
+pub mod back_button;
 pub mod bottom_button;
 pub mod safe_area;
+pub mod settings_button;
 pub mod theme;
 pub mod viewport;
 
+pub use back_button::BackButton;
 pub use bottom_button::BottomButton;
 pub use safe_area::{SafeAreaState, use_safe_area};
+pub use settings_button::SettingsButton;
 pub use theme::{ThemeState, use_theme};
 pub use viewport::{ViewportState, use_viewport};
 

--- a/src/yew/back_button.rs
+++ b/src/yew/back_button.rs
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::cell::RefCell;
+
+use yew::prelude::{Callback, Html, Properties, function_component, html, use_effect_with};
+
+use crate::{
+    logger,
+    webapp::{EventHandle, TelegramWebApp}
+};
+
+thread_local! {
+    static BACK_BUTTON_HANDLE: RefCell<Option<EventHandle<dyn FnMut()>>> =
+        const { RefCell::new(None) };
+}
+
+/// Props for [`BackButton`].
+#[derive(Properties, PartialEq)]
+pub struct BackButtonProps {
+    /// Whether the native back button is shown.
+    #[prop_or(true)]
+    pub visible:  bool,
+    /// Click handler.
+    #[prop_or_default]
+    pub on_click: Callback<()>
+}
+
+/// Yew component for the native back button.
+///
+/// Shows or hides `WebApp.BackButton` based on the `visible` prop and routes
+/// clicks through the `on_click` callback. The subscription is removed and the
+/// button hidden on unmount.
+///
+/// # Examples
+/// ```no_run
+/// use telegram_webapp_sdk::yew::BackButton;
+/// use yew::prelude::*;
+///
+/// #[function_component(App)]
+/// fn app() -> Html {
+///     let cb = Callback::from(|_| {
+///         web_sys::console::log_1(&"back".into());
+///     });
+///     html! { <BackButton visible={true} on_click={cb} /> }
+/// }
+/// ```
+#[function_component(BackButton)]
+pub fn back_button(props: &BackButtonProps) -> Html {
+    let visible = props.visible;
+    let on_click = props.on_click.clone();
+
+    use_effect_with(visible, move |&v| {
+        if let Some(app) = TelegramWebApp::instance() {
+            let result = if v {
+                app.show_back_button()
+            } else {
+                app.hide_back_button()
+            };
+            if let Err(err) = result {
+                logger::error(&format!("BackButton visibility toggle failed: {err:?}"));
+            }
+        }
+        || ()
+    });
+
+    use_effect_with((), move |()| {
+        if let Some(app) = TelegramWebApp::instance() {
+            match app.set_back_button_callback(move || on_click.emit(())) {
+                Ok(handle) => BACK_BUTTON_HANDLE.with(|c| {
+                    *c.borrow_mut() = Some(handle);
+                }),
+                Err(err) => logger::error(&format!("set_back_button_callback failed: {err:?}"))
+            }
+        }
+        || {
+            if let Some(app) = TelegramWebApp::instance() {
+                BACK_BUTTON_HANDLE.with(|c| {
+                    if let Some(handle) = c.borrow_mut().take()
+                        && let Err(err) = app.remove_back_button_callback(handle)
+                    {
+                        logger::error(&format!("remove_back_button_callback failed: {err:?}"));
+                    }
+                });
+                if let Err(err) = app.hide_back_button() {
+                    logger::error(&format!("hide_back_button failed: {err:?}"));
+                }
+            }
+        }
+    });
+
+    html! {}
+}

--- a/src/yew/settings_button.rs
+++ b/src/yew/settings_button.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use std::cell::RefCell;
+
+use yew::prelude::{Callback, Html, Properties, function_component, html, use_effect_with};
+
+use crate::{
+    logger,
+    webapp::{EventHandle, TelegramWebApp}
+};
+
+thread_local! {
+    static SETTINGS_BUTTON_HANDLE: RefCell<Option<EventHandle<dyn FnMut()>>> =
+        const { RefCell::new(None) };
+}
+
+/// Props for [`SettingsButton`].
+#[derive(Properties, PartialEq)]
+pub struct SettingsButtonProps {
+    /// Whether the native settings button is shown.
+    #[prop_or(true)]
+    pub visible:  bool,
+    /// Click handler.
+    #[prop_or_default]
+    pub on_click: Callback<()>
+}
+
+/// Yew component for the native settings button.
+///
+/// Shows or hides `WebApp.SettingsButton` based on the `visible` prop and
+/// routes clicks through the `on_click` callback. The subscription is removed
+/// and the button hidden on unmount.
+#[function_component(SettingsButton)]
+pub fn settings_button(props: &SettingsButtonProps) -> Html {
+    let visible = props.visible;
+    let on_click = props.on_click.clone();
+
+    use_effect_with(visible, move |&v| {
+        if let Some(app) = TelegramWebApp::instance() {
+            let result = if v {
+                app.show_settings_button()
+            } else {
+                app.hide_settings_button()
+            };
+            if let Err(err) = result {
+                logger::error(&format!("SettingsButton visibility toggle failed: {err:?}"));
+            }
+        }
+        || ()
+    });
+
+    use_effect_with((), move |()| {
+        if let Some(app) = TelegramWebApp::instance() {
+            match app.set_settings_button_callback(move || on_click.emit(())) {
+                Ok(handle) => SETTINGS_BUTTON_HANDLE.with(|c| {
+                    *c.borrow_mut() = Some(handle);
+                }),
+                Err(err) => logger::error(&format!("set_settings_button_callback failed: {err:?}"))
+            }
+        }
+        || {
+            if let Some(app) = TelegramWebApp::instance() {
+                SETTINGS_BUTTON_HANDLE.with(|c| {
+                    if let Some(handle) = c.borrow_mut().take()
+                        && let Err(err) = app.remove_settings_button_callback(handle)
+                    {
+                        logger::error(&format!("remove_settings_button_callback failed: {err:?}"));
+                    }
+                });
+                if let Err(err) = app.hide_settings_button() {
+                    logger::error(&format!("hide_settings_button failed: {err:?}"));
+                }
+            }
+        }
+    });
+
+    html! {}
+}


### PR DESCRIPTION
## Summary

Round out the system-button surface so Yew/Leptos mini-apps have the full set of declarative components (`MainButton`/`SecondaryButton` already shipped as `BottomButton`).

### `TelegramWebApp` (additive)

Add `SettingsButton` methods that mirror the existing `BackButton` shape, so both components target the same idiomatic API:
- `show_settings_button`, `hide_settings_button`
- `set_settings_button_callback(F) -> EventHandle<dyn FnMut()>`
- `remove_settings_button_callback(handle)`
- `is_settings_button_visible`

The standalone `src/api/settings_button.rs` static functions stay for backwards compatibility.

### Leptos (`leptos` feature)

- `src/leptos/back_button.rs::BackButton { visible: Signal<bool>, on_click: Option<F> }`
- `src/leptos/settings_button.rs::SettingsButton { visible: Signal<bool>, on_click: Option<F> }`

Each component reacts to `visible`, registers the click callback once, and hides the button + drops the `EventHandle` on `on_cleanup` via a module-scoped `thread_local!` slot (same pattern as `BottomButton`).

### Yew (`yew` feature)

- `src/yew/back_button.rs::BackButton { visible: bool, on_click: Callback<()> }`
- `src/yew/settings_button.rs::SettingsButton { visible: bool, on_click: Callback<()> }`

`use_effect_with(visible, …)` toggles show/hide on prop changes; `use_effect_with((), …)` registers the click handler and tears it down with the button on unmount.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (149/149)
- [ ] CI green