### PR TITLE
220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-13
+### Docs
+- README and `WEBAPP_API.md` aligned with the post-0.9.0 surface: `async fn` examples for one-shot calls, full Yew/Leptos system-button trio (`BottomButton`/`BackButton`/`SettingsButton`) and reactive hooks (`use_viewport`/`use_theme`/`use_safe_area`), new `Async API` and `Reactive hooks` sections, accurate features list, license corrected to MIT-only, version strings bumped to `0.9`, API coverage block bumped to 9.6, coverage badge and `WEBAPP_API.md` coverage commit pinned to the matching head (#219).
+
 ## [0.9.0] - 2026-05-13
 ### Added
 - **Leptos (`leptos` feature):** reactive hooks `use_viewport`, `use_theme`, `use_safe_area` returning `ReadSignal<*State>`. State structs `ViewportState`, `ThemeState`, `SafeAreaState`. Subscription auto-cleans on scope disposal (#211).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.9.0"
+version = "0.9.1"
 rust-version = "1.95.0"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION
## Summary

Release `0.9.1`. Patch bump — docs-only.

- `Cargo.toml`: `version 0.9.0 → 0.9.1`.
- `CHANGELOG.md`: promote `[Unreleased]` to `## [0.9.1] - 2026-05-13` summarising the doc alignment from #219.

Ships the post-0.9.0 README/`WEBAPP_API.md` corrections to docs.rs / crates.io users (currently those still see the stale 0.9.0 README with bad version strings, "Apache OR MIT" wording, and callback-only examples).

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (149/149)
- [ ] CI green