### PR TITLE
222

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,11 +598,11 @@ Persist small key-value pairs in Telegram's cloud using `CloudStorage`:
 
 ```rust,no_run
 use js_sys::Reflect;
-use telegram_webapp_sdk::api::cloud_storage::{get_items, set_items};
+use telegram_webapp_sdk::api::cloud_storage::{get_items, set_item};
 use wasm_bindgen_futures::JsFuture;
 
 # async fn run() -> Result<(), wasm_bindgen::JsValue> {
-JsFuture::from(set_items(&[("counter", "1")])?).await?;
+JsFuture::from(set_item("counter", "1")?).await?;
 let obj = JsFuture::from(get_items(&["counter"])?).await?;
 let value = Reflect::get(&obj, &"counter".into())?.as_string();
 assert_eq!(value, Some("1".into()));

--- a/WEBAPP_API.md
+++ b/WEBAPP_API.md
@@ -164,10 +164,8 @@ This checklist tracks support for the [Telegram Web Apps JavaScript API](https:/
 - [x] setItem ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] removeItem ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] getItems ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
-- [x] setItems ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] removeItems ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 - [x] getKeys ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
-- [x] clear ([ae2a302](https://github.com/RAprogramm/telegram-webapp-sdk/commit/ae2a302))
 
 ### DeviceStorage
 - [x] set ([0905616](https://github.com/RAprogramm/telegram-webapp-sdk/commit/0905616))

--- a/src/api/cloud_storage.rs
+++ b/src/api/cloud_storage.rs
@@ -104,31 +104,6 @@ pub fn get_items(keys: &[&str]) -> Result<Promise, JsValue> {
     func.call1(&storage, &array.into())?.dyn_into::<Promise>()
 }
 
-/// Calls `Telegram.WebApp.CloudStorage.setItems()`.
-///
-/// # Errors
-/// Returns `Err(JsValue)` if CloudStorage or the method is unavailable, or if
-/// the call fails.
-///
-/// # Examples
-/// ```no_run
-/// use telegram_webapp_sdk::api::cloud_storage::set_items;
-/// use wasm_bindgen_futures::JsFuture;
-/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// JsFuture::from(set_items(&[("a", "1"), ("b", "2")])?).await?;
-/// # Ok(())
-/// # }
-/// ```
-pub fn set_items(items: &[(&str, &str)]) -> Result<Promise, JsValue> {
-    let storage = cloud_storage_object()?;
-    let func = Reflect::get(&storage, &JsValue::from_str("setItems"))?.dyn_into::<Function>()?;
-    let obj = js_sys::Object::new();
-    for (key, value) in items {
-        Reflect::set(&obj, &JsValue::from_str(key), &JsValue::from_str(value))?;
-    }
-    func.call1(&storage, &obj.into())?.dyn_into::<Promise>()
-}
-
 /// Calls `Telegram.WebApp.CloudStorage.removeItems()`.
 ///
 /// # Errors
@@ -173,27 +148,6 @@ pub fn remove_items(keys: &[&str]) -> Result<Promise, JsValue> {
 pub fn get_keys() -> Result<Promise, JsValue> {
     let storage = cloud_storage_object()?;
     let func = Reflect::get(&storage, &JsValue::from_str("getKeys"))?.dyn_into::<Function>()?;
-    func.call0(&storage)?.dyn_into::<Promise>()
-}
-
-/// Calls `Telegram.WebApp.CloudStorage.clear()`.
-///
-/// # Errors
-/// Returns `Err(JsValue)` if CloudStorage or the method is unavailable, or if
-/// the call fails.
-///
-/// # Examples
-/// ```no_run
-/// use telegram_webapp_sdk::api::cloud_storage::clear;
-/// use wasm_bindgen_futures::JsFuture;
-/// # async fn run() -> Result<(), wasm_bindgen::JsValue> {
-/// JsFuture::from(clear()?).await?;
-/// # Ok(())
-/// # }
-/// ```
-pub fn clear() -> Result<Promise, JsValue> {
-    let storage = cloud_storage_object()?;
-    let func = Reflect::get(&storage, &JsValue::from_str("clear"))?.dyn_into::<Function>()?;
     func.call0(&storage)?.dyn_into::<Promise>()
 }
 
@@ -318,32 +272,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test(async)]
-    async fn set_items_ok() {
-        let storage = setup_cloud_storage();
-        let func =
-            Function::new_with_args("items", "this.called = items; return Promise.resolve();");
-        let _ = Reflect::set(&storage, &"setItems".into(), &func);
-        JsFuture::from(set_items(&[("a", "1"), ("b", "2")]).unwrap())
-            .await
-            .unwrap();
-        let called = Reflect::get(&storage, &"called".into()).unwrap();
-        assert_eq!(
-            Reflect::get(&called, &"a".into()).unwrap().as_string(),
-            Some("1".into())
-        );
-        assert_eq!(
-            Reflect::get(&called, &"b".into()).unwrap().as_string(),
-            Some("2".into())
-        );
-    }
-
-    #[wasm_bindgen_test]
-    fn set_items_err() {
-        let _ = setup_cloud_storage();
-        assert!(set_items(&[("a", "1")]).is_err());
-    }
-
-    #[wasm_bindgen_test(async)]
     async fn remove_items_ok() {
         let storage = setup_cloud_storage();
         let func =
@@ -379,25 +307,5 @@ mod tests {
     fn get_keys_err() {
         let _ = setup_cloud_storage();
         assert!(get_keys().is_err());
-    }
-
-    #[wasm_bindgen_test(async)]
-    async fn clear_ok() {
-        let storage = setup_cloud_storage();
-        let func = Function::new_no_args("this.called = true; return Promise.resolve();");
-        let _ = Reflect::set(&storage, &"clear".into(), &func);
-        JsFuture::from(clear().unwrap()).await.unwrap();
-        assert!(
-            Reflect::get(&storage, &"called".into())
-                .unwrap()
-                .as_bool()
-                .unwrap()
-        );
-    }
-
-    #[wasm_bindgen_test]
-    fn clear_err() {
-        let _ = setup_cloud_storage();
-        assert!(clear().is_err());
     }
 }

--- a/src/api/device_storage.rs
+++ b/src/api/device_storage.rs
@@ -104,7 +104,7 @@ fn device_storage_object() -> Result<JsValue, JsValue> {
     let window = window().ok_or_else(|| JsValue::from_str("no window"))?;
     let tg = Reflect::get(&window, &JsValue::from_str("Telegram"))?;
     let webapp = Reflect::get(&tg, &JsValue::from_str("WebApp"))?;
-    Reflect::get(&webapp, &JsValue::from_str("deviceStorage"))
+    Reflect::get(&webapp, &JsValue::from_str("DeviceStorage"))
 }
 
 #[cfg(test)]
@@ -126,7 +126,7 @@ mod tests {
         let storage = Object::new();
         let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
         let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
-        let _ = Reflect::set(&webapp, &"deviceStorage".into(), &storage);
+        let _ = Reflect::set(&webapp, &"DeviceStorage".into(), &storage);
         storage
     }
 

--- a/src/api/location_manager.rs
+++ b/src/api/location_manager.rs
@@ -117,7 +117,7 @@ fn location_manager_object() -> Result<JsValue, JsValue> {
     let window = window().ok_or_else(|| JsValue::from_str("no window"))?;
     let tg = Reflect::get(&window, &JsValue::from_str("Telegram"))?;
     let webapp = Reflect::get(&tg, &JsValue::from_str("WebApp"))?;
-    Reflect::get(&webapp, &JsValue::from_str("locationManager"))
+    Reflect::get(&webapp, &JsValue::from_str("LocationManager"))
 }
 
 fn webapp_object() -> Result<JsValue, JsValue> {
@@ -145,7 +145,7 @@ mod tests {
         let manager = Object::new();
         let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
         let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
-        let _ = Reflect::set(&webapp, &"locationManager".into(), &manager);
+        let _ = Reflect::set(&webapp, &"LocationManager".into(), &manager);
         (webapp, manager)
     }
 

--- a/src/api/secure_storage.rs
+++ b/src/api/secure_storage.rs
@@ -132,7 +132,7 @@ fn secure_storage_object() -> Result<JsValue, JsValue> {
     let window = window().ok_or_else(|| JsValue::from_str("no window"))?;
     let tg = Reflect::get(&window, &JsValue::from_str("Telegram"))?;
     let webapp = Reflect::get(&tg, &JsValue::from_str("WebApp"))?;
-    Reflect::get(&webapp, &JsValue::from_str("secureStorage"))
+    Reflect::get(&webapp, &JsValue::from_str("SecureStorage"))
 }
 
 #[cfg(test)]
@@ -154,7 +154,7 @@ mod tests {
         let storage = Object::new();
         let _ = Reflect::set(&win, &"Telegram".into(), &telegram);
         let _ = Reflect::set(&telegram, &"WebApp".into(), &webapp);
-        let _ = Reflect::set(&webapp, &"secureStorage".into(), &storage);
+        let _ = Reflect::set(&webapp, &"SecureStorage".into(), &storage);
         storage
     }
 


### PR DESCRIPTION
## Summary

Fix five long-standing phantom callsites that pretended to work because their mocks mirrored the bug. The actual `Telegram.WebApp` JS API never exposed any of them.

### Sub-object access keys (camelCase → PascalCase)

`Object.defineProperty(WebApp, 'DeviceStorage' | 'SecureStorage' | 'LocationManager', …)` is what real Telegram ships; the crate was looking up the camelCase mirrors, so every call into these modules failed at runtime in production. Tests passed because `setup_*` helpers set the camelCase key themselves — a closed loop with reality.

- `api::device_storage`: lookup `"deviceStorage"` → **`"DeviceStorage"`** (lib + test mock).
- `api::secure_storage`: lookup `"secureStorage"` → **`"SecureStorage"`** (lib + test mock).
- `api::location_manager`: lookup `"locationManager"` → **`"LocationManager"`** (lib + test mock).

### Removed phantom `CloudStorage` methods

`telegram-web-app.js` only exposes `setItem`, `getItem`, `getItems`, `removeItem`, `removeItems`, `getKeys`. There is **no** `setItems` and **no** `clear` on CloudStorage. The crate shipped both, dispatching to functions that don't exist; the `dyn_into::<Function>()?` cast failed the moment a real Telegram client ran the call.

- Drop `api::cloud_storage::set_items` (replaceable by a loop over `set_item`).
- Drop `api::cloud_storage::clear` (use `DeviceStorage` / `SecureStorage` if you need a bulk wipe).
- Update README `Cloud storage` snippet to call `set_item` instead.
- Drop the matching ✓ rows in `WEBAPP_API.md`.

### Why callers won't really notice

These functions threw on the first invocation against a live Telegram client, so the practical impact of the removal is *less* surprise, not more. The current SemVer position is 0.9.x — pre-1.0 — and breakage is documented.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --lib --all-features -p telegram-webapp-sdk` (21/21 native)
- [x] `cargo test --doc -p telegram-webapp-sdk --all-features` (182 doc-tests, 23 ignored)
- [x] `cargo +nightly-2025-08-01 fmt --all -- --check`
- [x] `cargo +1.95 clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `reuse lint` (149/149)
- [ ] CI green

Follow-up: release `0.10.0` since `set_items` and `clear` removal is a breaking public-API change.