### PR TITLE
#242 ci: harden dependabot config and pin release-plz actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,8 @@ updates:
   # 1) Rust / Cargo (workspace)
   - package-ecosystem: "cargo"
     directories:
-      - "/"            # корень с workspace Cargo.toml (оставь только реально существующие)
-      - "/api-server"
-      - "/client"
-      - "/crates/*"
+      - "/"                                 # root workspace (crate + demo + examples members)
+      - "/examples/integration/frontend"    # excluded from workspace, own Cargo.lock
     schedule:
       interval: "weekly"
       day: "monday"
@@ -42,15 +40,3 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps(ci)"
-
-  # 3) Docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:20"
-      timezone: "Asia/Ho_Chi_Minh"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "deps(docker)"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,18 +28,20 @@ jobs:
     name: Release-plz release
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'RAprogramm' }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Run release-plz release
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@d22c02a7cf6d7870bd163be7c7d9518d331aef34 # v0.5
         with:
           command: release
         env:
@@ -51,18 +53,21 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'RAprogramm' }}
     needs: release-plz-release
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Run release-plz release-pr
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@d22c02a7cf6d7870bd163be7c7d9518d331aef34 # v0.5
         with:
           command: release-pr
         env:


### PR DESCRIPTION
Closes #242

Reliability and supply-chain hardening for the CI/release setup.

## Changes
- **dependabot.yml:** fix the cargo `directories` — replace the copy-pasted non-existent `/api-server`, `/client`, `/crates/*` with the real layout: `/` (root workspace) and `/examples/integration/frontend` (excluded, independently-locked crate). Remove the `docker` ecosystem (no Dockerfile — those updater runs were failing).
- **release-plz.yml:** pin `actions/checkout`, `dtolnay/rust-toolchain`, and `release-plz/action` to full commit SHAs with version comments (this workflow handles `CARGO_REGISTRY_TOKEN` + `GH_TOKEN`). Dependabot's github-actions ecosystem keeps the SHAs current.
- **release-plz.yml:** add explicit least-privilege `permissions` per job (`contents: write` for release; `contents: write` + `pull-requests: write` for the release PR).

Verified: both YAML files parse, `reuse lint` passes.