### PR TITLE
#246 docs: publish EN/RU documentation site to GitHub Pages

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,57 @@
+# Build the multilingual (EN/RU) documentation site from wiki/ with mdBook and
+# deploy it to GitHub Pages. Source content lives in wiki/ (also synced to the
+# GitHub Wiki by wiki.yml); site/build.py assembles one mdBook per language plus
+# the landing page. Pages must be enabled with the "GitHub Actions" source.
+
+name: Docs Site
+
+on:
+  push:
+    branches: [main]
+    paths: ["wiki/**", "site/**", ".github/workflows/site.yml"]
+  pull_request:
+    paths: ["wiki/**", "site/**", ".github/workflows/site.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site from wiki
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2
+        with:
+          tool: mdbook@0.5.3
+
+      - name: Build site
+        run: python3 site/build.py --out "$RUNNER_TEMP/site"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: ${{ runner.temp }}/site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,39 @@
+# Mirror the wiki/ directory into the repository's GitHub Wiki on every push to
+# main that touches wiki/. The wiki is the human-editable source; the mdBook
+# site (site.yml) is generated from the same files. The wiki must be
+# initialized once (create any page in the GitHub UI) before the first push.
+
+name: Publish Wiki
+
+on:
+  push:
+    branches: [main]
+    paths: ["wiki/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Sync wiki/ to GitHub wiki
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Push wiki contents
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" /tmp/wiki
+          rsync -a --delete --exclude .git wiki/ /tmp/wiki/
+          cd /tmp/wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki already up to date"
+            exit 0
+          fi
+          git commit -m "docs: sync wiki from ${GITHUB_SHA}"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /wasmcov
 wasm-coverage
 demo/dist
+__pycache__/

--- a/site/build.py
+++ b/site/build.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""Build the multilingual documentation site from wiki/ with mdBook.
+
+Parses wiki/_Sidebar.md to discover languages and page order, generates one
+mdBook per language, rewrites wiki-style links to book-relative links, and
+assembles the final site with a landing page at the output root.
+
+Usage: python3 site/build.py --out <output-directory>
+"""
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import unquote
+
+REPO_URL = "https://github.com/RAprogramm/telegram-webapp-sdk"
+WIKI_URL = REPO_URL + "/wiki/"
+LANGUAGES = {
+    "English": "en",
+    "Русский": "ru",
+}
+
+HOME_RE = re.compile(r"^\*\*\[(.+?)\]\((\S+?)\)\*\*$")
+PART_RE = re.compile(r"^\*\*(.+?)\*\*$")
+PAGE_RE = re.compile(r"^- \[(.+?)\]\((\S+?)\)$")
+HEADING_RE = re.compile(r"^## (.+)$")
+LINK_RE = re.compile(r"\]\(([^)\s]+)\)")
+
+
+def slug_of(url):
+    return unquote(url.rsplit("/", 1)[-1])
+
+
+def parse_sidebar(text):
+    """Return {lang: [(kind, title, slug?), ...]} in sidebar order."""
+    books = {}
+    current = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        heading = HEADING_RE.match(line)
+        if heading:
+            current = None
+            for name, code in LANGUAGES.items():
+                if name in heading.group(1):
+                    current = code
+                    books[code] = []
+            continue
+        if current is None:
+            continue
+        m = HOME_RE.match(line)
+        if m:
+            books[current].append(("home", m.group(1), slug_of(m.group(2))))
+            continue
+        m = PART_RE.match(line)
+        if m:
+            books[current].append(("part", m.group(1), None))
+            continue
+        m = PAGE_RE.match(line)
+        if m:
+            books[current].append(("page", m.group(1), slug_of(m.group(2))))
+    return books
+
+
+def rewrite_links(text, lang, slug_lang):
+    """Rewrite wiki links: same book -> page.md, other book -> ../lang/page.html."""
+
+    def repl(match):
+        target = match.group(1)
+        if target.startswith(WIKI_URL):
+            target = target[len(WIKI_URL):]
+        elif "://" in target or target.startswith(("#", "mailto:")):
+            return match.group(0)
+        slug, _, anchor = target.partition("#")
+        slug = unquote(slug)
+        if slug not in slug_lang:
+            return match.group(0)
+        suffix = "#" + anchor if anchor else ""
+        if slug_lang[slug] == lang:
+            return "](" + slug + ".md" + suffix + ")"
+        return "](../" + slug_lang[slug] + "/" + slug + ".html" + suffix + ")"
+
+    return LINK_RE.sub(repl, text)
+
+
+def book_toml(lang):
+    return (
+        "[book]\n"
+        'title = "telegram-webapp-sdk"\n'
+        'language = "' + lang + '"\n'
+        'src = "src"\n'
+        "\n"
+        "[output.html]\n"
+        'site-url = "/telegram-webapp-sdk/' + lang + '/"\n'
+        'git-repository-url = "' + REPO_URL + '"\n'
+        'edit-url-template = "' + REPO_URL + '/edit/main/wiki/{path}"\n'
+        "\n"
+        "[output.html.playground]\n"
+        "runnable = false\n"
+    )
+
+
+def build_book(lang, items, wiki_dir, work_dir, out_dir, slug_lang):
+    book_dir = work_dir / lang
+    src_dir = book_dir / "src"
+    src_dir.mkdir(parents=True)
+    summary = ["# Summary", ""]
+    for kind, title, slug in items:
+        if kind == "home":
+            summary += ["[" + title + "](" + slug + ".md)", ""]
+        elif kind == "part":
+            summary += ["# " + title, ""]
+        else:
+            summary.append("- [" + title + "](" + slug + ".md)")
+    (src_dir / "SUMMARY.md").write_text("\n".join(summary) + "\n", encoding="utf-8")
+    for kind, _title, slug in items:
+        if kind == "part":
+            continue
+        text = (wiki_dir / (slug + ".md")).read_text(encoding="utf-8")
+        (src_dir / (slug + ".md")).write_text(
+            rewrite_links(text, lang, slug_lang), encoding="utf-8"
+        )
+    (book_dir / "book.toml").write_text(book_toml(lang), encoding="utf-8")
+    subprocess.run(
+        ["mdbook", "build", "--dest-dir", str(out_dir / lang)],
+        cwd=book_dir,
+        check=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    wiki_dir = repo_root / "wiki"
+    out_dir = args.out.resolve()
+
+    books = parse_sidebar((wiki_dir / "_Sidebar.md").read_text(encoding="utf-8"))
+    missing = sorted(set(LANGUAGES.values()) - set(books))
+    if missing:
+        sys.exit("languages missing from wiki/_Sidebar.md: " + ", ".join(missing))
+
+    slug_lang = {
+        slug: lang
+        for lang, items in books.items()
+        for kind, _title, slug in items
+        if kind != "part"
+    }
+
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    with tempfile.TemporaryDirectory() as work:
+        for lang, items in books.items():
+            build_book(lang, items, wiki_dir, Path(work), out_dir, slug_lang)
+
+    shutil.copy(repo_root / "site" / "landing.html", out_dir / "index.html")
+    shutil.copy(repo_root / "tg-webapp-sdk.png", out_dir / "logo.png")
+    print("site built at", out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/landing.html
+++ b/site/landing.html
@@ -1,0 +1,94 @@
+<!-- SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="telegram-webapp-sdk documentation — Telegram Mini Apps (WebApp) SDK for Rust and WebAssembly">
+<title>telegram-webapp-sdk — Documentation</title>
+<link rel="icon" type="image/png" href="logo.png">
+<style>
+  :root {
+    --bg: #fdfdfd;
+    --fg: #1f2328;
+    --muted: #57606a;
+    --card-bg: #ffffff;
+    --card-border: #d0d7de;
+    --card-hover: #0969da;
+    --accent: #0969da;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --fg: #e6edf3;
+      --muted: #8d96a0;
+      --card-bg: #161b22;
+      --card-border: #30363d;
+      --card-hover: #58a6ff;
+      --accent: #58a6ff;
+    }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+    text-align: center;
+  }
+  img.logo { width: 140px; height: 140px; object-fit: contain; }
+  h1 { margin-top: 1rem; font-size: 2.2rem; }
+  p.tagline { margin-top: .5rem; color: var(--muted); font-size: 1.1rem; font-style: italic; }
+  nav.languages {
+    margin-top: 2.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    width: 100%;
+    max-width: 640px;
+  }
+  nav.languages a {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 1.4rem 1rem;
+    text-decoration: none;
+    color: var(--fg);
+    transition: border-color .15s, transform .15s;
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+  }
+  nav.languages a:hover {
+    border-color: var(--card-hover);
+    transform: translateY(-2px);
+  }
+  nav.languages .flag { font-size: 2rem; }
+  nav.languages .name { font-weight: 600; font-size: 1.05rem; }
+  nav.languages .label { color: var(--muted); font-size: .9rem; }
+  footer { margin-top: 3rem; color: var(--muted); font-size: .95rem; }
+  footer a { color: var(--accent); text-decoration: none; }
+  footer a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+  <img class="logo" src="logo.png" alt="telegram-webapp-sdk logo">
+  <h1>telegram-webapp-sdk</h1>
+  <p class="tagline">Telegram Mini Apps for Rust &amp; WebAssembly</p>
+  <nav class="languages" aria-label="Documentation language">
+    <a href="en/"><span class="flag">🇬🇧</span><span class="name">English</span><span class="label">Documentation</span></a>
+    <a href="ru/" lang="ru"><span class="flag">🇷🇺</span><span class="name">Русский</span><span class="label">Документация</span></a>
+  </nav>
+  <footer>
+    <a href="https://docs.rs/telegram-webapp-sdk">API&nbsp;Docs</a> ·
+    <a href="https://crates.io/crates/telegram-webapp-sdk">crates.io</a> ·
+    <a href="https://github.com/RAprogramm/telegram-webapp-sdk">GitHub</a>
+  </footer>
+</body>
+</html>

--- a/wiki/Examples-en.md
+++ b/wiki/Examples-en.md
@@ -1,0 +1,89 @@
+# Examples
+
+The repository ships several runnable examples, wired into the Cargo workspace.
+Each shows a different integration style — from a full Trunk-built Mini App down
+to a plain WASM binary and the bot side of a full-stack app.
+
+## `demo/` — Trunk WASM app
+
+A complete Mini App built with the `macros` and `mock` features. It uses
+`telegram_page!` / `telegram_router!` for routing and includes components and
+pages (`demo/src/components`, `demo/src/pages`). Because it enables `mock`, it
+runs in an ordinary browser during development.
+
+```bash
+cd demo
+trunk serve        # dev server with live reload at http://localhost:8080
+trunk build --release
+```
+
+The `demo/index.html` loads Telegram's `telegram-web-app.js` and the Trunk-built
+WASM bundle.
+
+## `examples/vanilla` — no framework
+
+A pure-WebAssembly example (`examples/vanilla/src/main.rs` + `ui.rs`) that uses
+the SDK and the DOM helpers directly, with no Yew or Leptos. It depends on the
+crate with the `mock` feature, so it runs standalone. Good starting point if you
+want full control over the DOM.
+
+```bash
+cd examples/vanilla
+trunk serve
+```
+
+## `examples/bots/rust_bot` — Telegram bot
+
+A [teloxide](https://github.com/teloxide/teloxide)-based bot
+(`examples/bots/rust_bot`) that opens the demo Mini App via WebApp buttons and
+receives orders sent from the app through `sendData`. This is the server side —
+it is a native binary, not WASM.
+
+```bash
+cd examples/bots/rust_bot
+cp .env.example .env          # add your TELOXIDE_TOKEN
+cargo run
+```
+
+Requires a bot token from [@BotFather](https://t.me/BotFather) and an
+HTTPS-served WebApp URL.
+
+## `examples/integration` — full-stack
+
+A two-part example showing the frontend↔backend round trip:
+
+- `examples/integration/frontend` — a WASM Mini App that sends a JSON message to
+  the bot via `TelegramWebApp::send_data(...)`. (This member is excluded from the
+  workspace and built on its own with Trunk.)
+- `examples/integration/backend` — a teloxide bot that receives the update's
+  `web_app_data`, parses the JSON, and replies.
+
+```bash
+# terminal 1 — backend
+cd examples/integration/backend
+cargo run
+
+# terminal 2 — frontend
+cd examples/integration/frontend
+trunk serve
+```
+
+The data flow: the user opens the Mini App → interacts with the UI → the app
+calls `send_data` → Telegram delivers the payload to the bot as `web_app_data` →
+the bot processes it and replies.
+
+## Building any WASM example
+
+All the browser-side examples build for `wasm32-unknown-unknown` and are served
+with Trunk:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install trunk
+```
+
+## See also
+
+- [Quick Start](Quick-Start-en) — the minimal version of the vanilla example
+- [Framework Integration](Framework-Integration-en) — Leptos/Yew patterns used in the demo
+- [Mock & Testing](Testing-en) — the `mock` feature that lets these examples run outside Telegram

--- a/wiki/Framework-Integration-en.md
+++ b/wiki/Framework-Integration-en.md
@@ -1,0 +1,154 @@
+# Framework Integration
+
+The crate ships optional integrations for [Leptos](https://leptos.dev) (feature
+`leptos`) and [Yew](https://yew.rs) (feature `yew`). Both expose the same three
+reactive hooks and the same three system-button components. The hooks seed their
+state with the current values and re-render when Telegram fires
+`viewportChanged`, `themeChanged`, `safeAreaChanged`, or
+`contentSafeAreaChanged`. Subscriptions are cleaned up automatically on
+unmount / scope disposal.
+
+## Leptos
+
+Provide the context once near the root, then read it with `use_context`:
+
+```rust,ignore
+use leptos::prelude::*;
+use telegram_webapp_sdk::{core::context::TelegramContext, leptos::provide_telegram_context};
+
+#[component]
+fn App() -> impl IntoView {
+    provide_telegram_context().expect("context");
+    let ctx = use_context::<TelegramContext>().expect("context");
+    view! { <span>{ ctx.init_data.auth_date }</span> }
+}
+```
+
+### Reactive hooks
+
+In Leptos the hooks return `ReadSignal<T>`, so you read them through `.get()`
+inside a closure:
+
+```rust,ignore
+use leptos::prelude::*;
+use telegram_webapp_sdk::leptos::{use_safe_area, use_theme, use_viewport};
+
+#[component]
+fn Status() -> impl IntoView {
+    let viewport = use_viewport(); // ReadSignal<ViewportState>
+    let theme = use_theme();       // ReadSignal<ThemeState>
+    let safe = use_safe_area();    // ReadSignal<SafeAreaState>
+    view! {
+        <div>
+            { move || viewport.get().height }
+            { move || theme.get().color_scheme.unwrap_or_default() }
+            { move || safe.get().area.map(|i| i.top).unwrap_or(0.0) }
+        </div>
+    }
+}
+```
+
+`ViewportState` carries `height`, `stable_height`, and `is_expanded`.
+`ThemeState` carries `color_scheme: Option<String>` and a parsed `params`
+palette. `SafeAreaState` carries `area` and `content` as `Option<SafeAreaInset>`.
+
+### Components
+
+`BottomButton` takes a `button` selector plus reactive `text` (and optional
+`color` / `text_color` / `on_click`). `BackButton` and `SettingsButton` take a
+reactive `visible` signal and an optional `on_click` closure. All three drive the
+native Telegram buttons and clean up on unmount.
+
+```rust,ignore
+use leptos::prelude::*;
+use telegram_webapp_sdk::{
+    leptos::{provide_telegram_context, BackButton, BottomButton, SettingsButton},
+    webapp::BottomButton as Btn,
+};
+
+#[component]
+fn App() -> impl IntoView {
+    provide_telegram_context().expect("context");
+    let (text, _set_text) = signal("Send".to_owned());
+    let visible = RwSignal::new(true);
+    view! {
+        <BottomButton button=Btn::Main text on_click=move || { /* submit */ } />
+        <BackButton visible=visible on_click=move || { /* navigate back */ } />
+        <SettingsButton visible=visible on_click=move || { /* open settings */ } />
+    }
+}
+```
+
+## Yew
+
+Read the context with the `use_telegram_context` hook. It returns
+`Result<TelegramContext, JsValue>` and reactively resolves once the context is
+initialized:
+
+```rust,ignore
+use telegram_webapp_sdk::yew::use_telegram_context;
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    match use_telegram_context() {
+        Ok(ctx) => html! { <span>{ ctx.init_data.auth_date }</span> },
+        Err(_) => html! { <div>{ "Loading Telegram context..." }</div> },
+    }
+}
+```
+
+### Reactive hooks
+
+In Yew the hooks return the state value directly (not a signal), so you read
+fields straight off it:
+
+```rust,ignore
+use telegram_webapp_sdk::yew::{use_safe_area, use_theme, use_viewport};
+use yew::prelude::*;
+
+#[function_component(Status)]
+fn status() -> Html {
+    let viewport = use_viewport(); // ViewportState
+    let theme = use_theme();       // ThemeState
+    let safe = use_safe_area();    // SafeAreaState
+    html! {
+        <div>
+            { viewport.height }
+            { theme.color_scheme.clone().unwrap_or_default() }
+            { safe.area.map(|i| i.top).unwrap_or(0.0) }
+        </div>
+    }
+}
+```
+
+### Components
+
+Yew's components take plain props: `BottomButton` uses `text` / `color` /
+`text_color` / `on_click` (it always drives the Main button), while `BackButton`
+and `SettingsButton` take a `visible: bool` prop and an `on_click: Callback<()>`.
+
+```rust,ignore
+use telegram_webapp_sdk::yew::{BackButton, BottomButton, SettingsButton};
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    let on_main = Callback::from(|_| {});
+    let on_back = Callback::from(|_| {});
+    let on_settings = Callback::from(|_| {});
+    html! {
+        <>
+            <BottomButton text="Send" color="#000" text_color="#fff" on_click={on_main} />
+            <BackButton visible={true} on_click={on_back} />
+            <SettingsButton visible={true} on_click={on_settings} />
+        </>
+    }
+}
+```
+
+## See also
+
+- [Quick Start](Quick-Start-en) — the vanilla (no-framework) flow
+- [Mock & Testing](Testing-en) — render components against a mock environment
+- [Examples](Examples-en) — a runnable Trunk demo

--- a/wiki/Home-en.md
+++ b/wiki/Home-en.md
@@ -1,0 +1,58 @@
+# Home
+
+`telegram-webapp-sdk` is a type-safe, ergonomic Rust/WASM wrapper around the
+[Telegram Web Apps](https://core.telegram.org/bots/webapps) JavaScript API. It
+lets you build Telegram Mini Apps entirely in Rust — with vanilla WebAssembly,
+or through first-class [Yew](https://yew.rs) and [Leptos](https://leptos.dev)
+integrations.
+
+## API coverage
+
+The crate tracks the **Telegram WebApp API version 9.6**, which is the latest
+Mini App surface exposed by `telegram-web-app.js`. Bot API has since advanced to
+10.1, but versions 9.7–10.1 introduced no new WebApp methods, fields, or events,
+so the covered surface is complete. Bot API 9.5 added `icon_custom_emoji_id` for
+bottom buttons; 9.6 added `WebApp.requestChat` and the `requestedChatSent` /
+`requestedChatFailed` events — both are implemented.
+
+The covered surface includes:
+
+- Buttons: Main, Secondary, Back, and Settings buttons
+- Dialogs: alert, confirm, popup, and QR-code scanner
+- Navigation, links, sharing, and invoices
+- Theme, colors, viewport, and safe-area insets
+- Storage: CloudStorage, DeviceStorage, and SecureStorage
+- Sensors: accelerometer, gyroscope, device orientation, and LocationManager
+- Biometric authentication and haptic feedback
+
+For the full method-by-method checklist, see
+[`WEBAPP_API.md`](https://github.com/RAprogramm/telegram-webapp-sdk/blob/main/WEBAPP_API.md).
+
+## Feature flags
+
+The crate is `default = []` — enable only what you need.
+
+| Feature  | What it enables |
+|----------|-----------------|
+| `macros` | `telegram_app!`, `telegram_page!`, and `telegram_router!` for boilerplate-free apps and routing |
+| `yew`    | `use_telegram_context`, reactive `use_viewport` / `use_theme` / `use_safe_area` hooks, and `BottomButton` / `BackButton` / `SettingsButton` components |
+| `leptos` | `provide_telegram_context`, the same reactive `use_*` hooks, and matching Leptos components |
+| `mock`   | A configurable mock `Telegram.WebApp` for local development and testing |
+| `full`   | Aggregates `macros`, `yew`, `leptos`, and `mock` |
+
+```toml
+telegram-webapp-sdk = { version = "0.11", features = ["leptos", "mock"] }
+```
+
+## Documentation index
+
+- [Installation](Installation-en) — dependency line, feature flags, MSRV, and the wasm32 target
+- [Quick Start](Quick-Start-en) — obtain the WebApp instance, `ready()`/`expand()`, read init data, and wire up a MainButton
+- [WebApp API](WebApp-API-en) — a tour of the covered surface grouped by area, plus the `*_with_callback` vs `async` pattern
+- [Framework Integration](Framework-Integration-en) — Leptos and Yew hooks and components
+- [Mock & Testing](Testing-en) — the `mock` feature and `wasm_bindgen_test`
+- [Examples](Examples-en) — the demo app, vanilla example, bot, and full-stack integration
+
+## License
+
+`telegram-webapp-sdk` is licensed under the MIT license.

--- a/wiki/Installation-en.md
+++ b/wiki/Installation-en.md
@@ -1,0 +1,90 @@
+# Installation
+
+## Add the dependency
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+telegram-webapp-sdk = "0.11"
+```
+
+## Enable feature flags
+
+The crate ships with **no default features** (`default = []`), so you opt into
+exactly what you need:
+
+```toml
+telegram-webapp-sdk = { version = "0.11", features = ["macros", "yew", "leptos", "mock"] }
+```
+
+| Feature  | Purpose |
+|----------|---------|
+| `macros` | `telegram_app!`, `telegram_page!`, and `telegram_router!` macros |
+| `yew`    | Yew context hook, reactive hooks, and system-button components |
+| `leptos` | Leptos context provider, reactive hooks, and system-button components |
+| `mock`   | Configurable mock `Telegram.WebApp` for local development |
+| `full`   | Shortcut for `macros` + `yew` + `leptos` + `mock` |
+
+Typically you enable a single framework feature plus `mock`:
+
+```toml
+# Leptos app with local mock support
+telegram-webapp-sdk = { version = "0.11", features = ["leptos", "mock"] }
+```
+
+## Minimum Supported Rust Version
+
+The MSRV is **Rust 1.96** (edition 2024). Older toolchains are not supported.
+
+```bash
+rustup update stable
+rustc --version   # must be >= 1.96
+```
+
+## Target the browser
+
+Telegram Mini Apps run as WebAssembly in the Telegram in-app browser, so you
+build for the `wasm32-unknown-unknown` target:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+## Bundling with Trunk or wasm-pack
+
+Use a WASM bundler to produce the final `.wasm` + JS glue and an `index.html`.
+
+**Trunk** (recommended for whole apps — this is what the demo uses):
+
+```bash
+cargo install trunk
+trunk serve   # dev server with live reload
+trunk build --release
+```
+
+A minimal `index.html` for Trunk pulls in Telegram's script and your crate:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <link data-trunk rel="rust" />
+  </head>
+  <body></body>
+</html>
+```
+
+**wasm-pack** (for libraries or JS-driven integration):
+
+```bash
+cargo install wasm-pack
+wasm-pack build --target web
+```
+
+## Next steps
+
+- [Quick Start](Quick-Start-en) — initialize the SDK and show your first button
+- [Framework Integration](Framework-Integration-en) — wire up Leptos or Yew
+- [Mock & Testing](Testing-en) — run outside Telegram during development

--- a/wiki/Quick-Start-en.md
+++ b/wiki/Quick-Start-en.md
@@ -1,0 +1,108 @@
+# Quick Start
+
+This page walks through the smallest useful Mini App: initialize the SDK, obtain
+the WebApp instance, signal readiness, read the launch data, and show a MainButton.
+
+## 1. Initialize the SDK and get the instance
+
+`init_sdk()` parses `initData` and `themeParams` from `Telegram.WebApp` and
+stores them in a global context. After that, obtain the live WebApp handle.
+
+There are two accessors:
+
+- `TelegramWebApp::instance()` returns `Option<TelegramWebApp>` (`None` when not
+  running inside Telegram) — handy for graceful degradation.
+- `TelegramWebApp::try_instance()` returns `Result<TelegramWebApp, JsValue>` —
+  handy inside `?`-using functions.
+
+```rust,ignore
+use telegram_webapp_sdk::{core::init::init_sdk, webapp::TelegramWebApp};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn main() -> Result<(), JsValue> {
+    init_sdk()?;
+
+    let app = TelegramWebApp::try_instance()?;
+    app.ready()?;   // tell Telegram the interface is initialized
+    app.expand()?;  // expand the Mini App to full height
+
+    Ok(())
+}
+```
+
+If you prefer non-panicking startup, use `try_init_sdk()`, which returns
+`Ok(false)` when Telegram is not present:
+
+```rust,ignore
+use telegram_webapp_sdk::core::init::try_init_sdk;
+
+match try_init_sdk() {
+    Ok(true) => { /* running inside Telegram */ }
+    Ok(false) => { /* regular browser — use a fallback */ }
+    Err(e) => eprintln!("init failed: {e}")
+}
+```
+
+## 2. Read init data and the user
+
+Parsed launch data lives in the global `TelegramContext`. Access it through the
+closure-based getter:
+
+```rust,ignore
+use telegram_webapp_sdk::core::context::TelegramContext;
+
+TelegramContext::get(|ctx| {
+    if let Some(user) = &ctx.init_data.user {
+        web_sys::console::log_1(&format!("Hello, {}", user.first_name).into());
+    }
+    let _ = ctx.init_data.auth_date;
+    let _ = ctx.init_data.start_param.as_deref();
+});
+```
+
+For server-side signature validation, grab the raw URL-encoded string and POST
+it to your backend (validate it there with your bot token, never on the client):
+
+```rust,ignore
+use telegram_webapp_sdk::TelegramWebApp;
+
+let raw_init_data = TelegramWebApp::get_raw_init_data()?;
+// POST /auth  { "init_data": raw_init_data }
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## 3. A minimal MainButton
+
+Set the label, show the button, and register a click callback. The callback
+returns an `EventHandle` you can later pass to `remove_main_button_callback`.
+
+```rust,ignore
+use telegram_webapp_sdk::webapp::TelegramWebApp;
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+
+app.set_main_button_text("Send order")?;
+app.set_main_button_color("#2481cc")?;
+app.enable_main_button()?;
+app.show_main_button()?;
+
+let handle = app.set_main_button_callback(|| {
+    if let Some(app) = TelegramWebApp::instance() {
+        let _ = app.send_data("order-confirmed");
+    }
+})?;
+
+// later, when the button is no longer needed:
+app.remove_main_button_callback(handle)?;
+app.hide_main_button()?;
+# Ok(())
+# }
+```
+
+## Where to next
+
+- [WebApp API](WebApp-API-en) — the full covered surface, including dialogs, storage, and sensors
+- [Framework Integration](Framework-Integration-en) — reactive hooks and button components for Leptos/Yew
+- [Mock & Testing](Testing-en) — run this code outside Telegram

--- a/wiki/Testing-en.md
+++ b/wiki/Testing-en.md
@@ -1,0 +1,121 @@
+# Mock & Testing
+
+The `mock` feature installs a configurable fake `Telegram.WebApp` object on
+`window`, so you can develop and test outside the Telegram client. Enable it:
+
+```toml
+telegram-webapp-sdk = { version = "0.11", features = ["mock"] }
+```
+
+## Installing a mock environment
+
+The mock lives under `telegram_webapp_sdk::mock`. Build a `MockTelegramConfig`
+(it implements `Default`) and call `mock_telegram_webapp`, which injects
+`window.Telegram.WebApp` with mocked `initData`, `themeParams`, `platform`, and
+`version`. Use it only in debug builds.
+
+```rust,ignore
+use telegram_webapp_sdk::mock::{config::MockTelegramConfig, init::mock_telegram_webapp};
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let config = MockTelegramConfig::default();
+mock_telegram_webapp(config)?;
+// window.Telegram.WebApp now exists — the SDK behaves as if inside Telegram.
+# Ok(())
+# }
+```
+
+### Customizing the mocked data
+
+`MockTelegramConfig` exposes optional fields for the user, auth data, every
+theme color, and the platform/version. A mocked user is a `MockTelegramUser`:
+
+```rust,ignore
+use telegram_webapp_sdk::mock::{
+    config::MockTelegramConfig, data::MockTelegramUser, init::mock_telegram_webapp,
+};
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let config = MockTelegramConfig {
+    user: Some(MockTelegramUser {
+        id: 42,
+        first_name: "Alice".into(),
+        username: Some("alice".into()),
+        language_code: Some("en".into()),
+        ..Default::default()
+    }),
+    platform: Some("android".into()),
+    version: Some("9.6".into()),
+    ..Default::default()
+};
+mock_telegram_webapp(config)?;
+# Ok(())
+# }
+```
+
+You can also load the config from a TOML file (the same `telegram-webapp.toml`
+that `telegram_app!` reads in debug builds):
+
+```rust,ignore
+use telegram_webapp_sdk::mock::config::MockTelegramConfig;
+
+let config = MockTelegramConfig::from_file("telegram-webapp.toml")?;
+# Ok::<(), std::io::Error>(())
+```
+
+## Testing with `wasm_bindgen_test`
+
+Because the SDK talks to browser globals, tests run in a headless browser via
+`wasm-bindgen-test`. Add it as a dev-dependency:
+
+```toml
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+```
+
+Configure the tests to run in a browser and install the mock before exercising
+the SDK:
+
+```rust,ignore
+use telegram_webapp_sdk::{
+    core::init::init_sdk,
+    mock::{config::MockTelegramConfig, init::mock_telegram_webapp},
+    webapp::TelegramWebApp,
+};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn instance_is_available_after_mock() {
+    mock_telegram_webapp(MockTelegramConfig::default()).expect("mock installed");
+    init_sdk().expect("sdk initialized");
+
+    let app = TelegramWebApp::instance().expect("instance");
+    app.ready().expect("ready");
+}
+```
+
+Run the suite against a real browser engine:
+
+```bash
+# Chrome / Chromium
+wasm-pack test --headless --chrome
+
+# or Firefox
+wasm-pack test --headless --firefox
+```
+
+## Tips
+
+- Prefer `TelegramWebApp::instance()` (returning `Option`) in app code so the
+  same binary degrades gracefully when neither Telegram nor the mock is present.
+- Each `wasm_bindgen_test` shares one `window`; install the mock at the start of
+  every test that needs it rather than relying on ordering.
+- Note that `TelegramContext::init` succeeds only once per thread — design tests
+  so they do not depend on re-initializing the global context.
+
+## See also
+
+- [Quick Start](Quick-Start-en) — the code you are testing
+- [Examples](Examples-en) — the `examples/vanilla` app builds with the `mock` feature

--- a/wiki/WebApp-API-en.md
+++ b/wiki/WebApp-API-en.md
@@ -1,0 +1,187 @@
+# WebApp API
+
+Almost every capability hangs off the `TelegramWebApp` handle
+(`instance()` / `try_instance()`), with a few free-function modules under
+`telegram_webapp_sdk::api::*` for sensors, storage, haptics, and theme. This
+page groups the surface by area. For the exhaustive checklist, see
+[`WEBAPP_API.md`](https://github.com/RAprogramm/telegram-webapp-sdk/blob/main/WEBAPP_API.md).
+
+## The `*_with_callback` vs `async` pattern
+
+Every one-shot Telegram callback has **two** Rust siblings:
+
+- `foo_with_callback(..., F)` — synchronous registration; your closure runs when
+  Telegram fires the result. Use it when you cannot `.await` (e.g. inside a
+  non-async closure).
+- `async fn foo(...)` — returns the natural Rust type via `.await`. Prefer this
+  in production code.
+
+```rust,no_run
+use telegram_webapp_sdk::webapp::TelegramWebApp;
+
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+
+let confirmed: bool = app.show_confirm("Send the order?").await?;
+let scanned: String = app.show_scan_qr_popup("Scan a QR code").await?;
+let granted: bool = app.request_write_access().await?;
+let _ = (confirmed, scanned, granted);
+# Ok(())
+# }
+```
+
+The same dual applies to `share_message`, `request_chat`,
+`check_home_screen_status`, `set_emoji_status`, `request_emoji_status_access`,
+`open_invoice`, `download_file`, `read_text_from_clipboard`, `show_popup`, and
+`invoke_custom_method`.
+
+## Buttons
+
+Main and Secondary bottom buttons share a `BottomButton` selector enum
+(`BottomButton::Main` / `BottomButton::Secondary`):
+
+```rust,no_run
+use telegram_webapp_sdk::webapp::{BottomButton, BottomButtonParams, TelegramWebApp};
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+
+app.set_bottom_button_text(BottomButton::Main, "Submit")?;
+app.show_bottom_button(BottomButton::Main)?;
+
+// Atomic update via setParams:
+let params = BottomButtonParams {
+    text: Some("Submit"),
+    color: Some("#2481cc"),
+    text_color: Some("#ffffff"),
+    is_active: Some(true),
+    is_visible: Some(true),
+    icon_custom_emoji_id: Some("123456789"), // Bot API 9.5+
+    ..Default::default()
+};
+app.set_bottom_button_params(BottomButton::Main, &params)?;
+# Ok(())
+# }
+```
+
+Convenience aliases exist for the main button (`set_main_button_text`,
+`show_main_button`, `enable_main_button`, `set_main_button_callback`, …) and the
+secondary button (`set_secondary_button_text`, `show_secondary_button`, …).
+
+Back and Settings buttons are driven directly:
+
+```rust,no_run
+# use telegram_webapp_sdk::webapp::TelegramWebApp;
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+app.show_back_button()?;
+let handle = app.set_back_button_callback(|| { /* navigate back */ })?;
+app.remove_back_button_callback(handle)?;
+
+app.show_settings_button()?;
+let sh = app.set_settings_button_callback(|| { /* open settings */ })?;
+app.remove_settings_button_callback(sh)?;
+# Ok(())
+# }
+```
+
+## Dialogs
+
+```rust,no_run
+# use telegram_webapp_sdk::webapp::TelegramWebApp;
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+app.show_alert("Saved!")?;
+let ok: bool = app.show_confirm("Delete this item?").await?;
+let button_id: String = app.show_popup(&wasm_bindgen::JsValue::NULL).await?;
+let code: String = app.show_scan_qr_popup("Point at a QR code").await?;
+app.close_scan_qr_popup()?;
+let _ = (ok, button_id, code);
+# Ok(())
+# }
+```
+
+## Navigation and links
+
+`open_link` (with optional `OpenLinkOptions`), `open_telegram_link`,
+`switch_inline_query`, `share_url`, `share_message` / `share_to_story`,
+`request_chat`, `add_to_home_screen`, and `check_home_screen_status`.
+
+## Theme and colors
+
+`set_header_color`, `set_background_color`, `set_bottom_bar_color`,
+`color_scheme()`, plus the free function
+`telegram_webapp_sdk::api::theme::get_theme_params()` returning a parsed palette.
+
+## Viewport and safe area
+
+`viewport_height()`, `viewport_width()`, `viewport_stable_height()`,
+`expand_viewport()`, and the `SafeAreaInset` accessors `safe_area_inset()` /
+`content_safe_area_inset()`. Fullscreen and orientation live under
+`request_fullscreen`, `exit_fullscreen`, `is_fullscreen`, `lock_orientation`,
+and `unlock_orientation`.
+
+## Storage
+
+- **CloudStorage** — `api::cloud_storage::{get_item, set_item, remove_item, get_items, remove_items, get_keys}` (each returns a JS `Promise`).
+- **DeviceStorage** — `api::device_storage::{set, get, remove, clear}` (`async`).
+- **SecureStorage** — `api::secure_storage::{set, get, restore, remove, clear}` (`async`).
+
+```rust,no_run
+use telegram_webapp_sdk::api::device_storage::{get, set};
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+set("theme", "dark").await?;
+let value: Option<String> = get("theme").await?;
+let _ = value;
+# Ok(())
+# }
+```
+
+## Sensors
+
+Accelerometer, gyroscope, and device orientation each expose `start()`,
+`stop()`, a getter (`get_acceleration()`, `get_angular_velocity()`,
+`get_orientation()`), and lifecycle callbacks `on_started` / `on_changed` /
+`on_stopped` / `on_failed`. LocationManager offers `init()`, `get_location()`,
+`open_settings()`, `on_location_manager_updated`, and `on_location_requested`.
+
+```rust,no_run
+use telegram_webapp_sdk::api::accelerometer::{get_acceleration, start, stop};
+start()?;
+let reading = get_acceleration();
+stop()?;
+let _ = reading;
+# Ok::<(), wasm_bindgen::JsValue>(())
+```
+
+## Biometry
+
+`api::biometric::{init, is_biometric_available, request_access, authenticate, update_biometric_token, open_settings, is_inited, is_access_granted, device_id, …}`.
+
+```rust,no_run
+use telegram_webapp_sdk::api::biometric::{authenticate, init, is_biometric_available, request_access};
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+init()?;
+if is_biometric_available()? {
+    request_access("auth-key", Some("Unlock the vault"), None)?;
+    authenticate("auth-key", None, None)?;
+}
+# Ok(())
+# }
+```
+
+## Haptics
+
+```rust,no_run
+use telegram_webapp_sdk::api::haptic::{
+    impact_occurred, notification_occurred, selection_changed,
+    HapticImpactStyle, HapticNotificationType,
+};
+impact_occurred(HapticImpactStyle::Light)?;
+notification_occurred(HapticNotificationType::Success)?;
+selection_changed()?;
+# Ok::<(), wasm_bindgen::JsValue>(())
+```
+
+See also [Framework Integration](Framework-Integration-en) for reactive wrappers
+over viewport, theme, and safe-area events.

--- a/wiki/WebApp-API-ru.md
+++ b/wiki/WebApp-API-ru.md
@@ -1,0 +1,189 @@
+# WebApp API
+
+Почти все возможности доступны через хендл `TelegramWebApp`
+(`instance()` / `try_instance()`), плюс несколько модулей со свободными
+функциями в `telegram_webapp_sdk::api::*` для сенсоров, хранилищ, тактильной
+отдачи и темы. Эта страница группирует поверхность по разделам. Исчерпывающий
+чек-лист — в
+[`WEBAPP_API.md`](https://github.com/RAprogramm/telegram-webapp-sdk/blob/main/WEBAPP_API.md).
+
+## Паттерн `*_with_callback` против `async`
+
+У каждого одноразового колбэка Telegram есть **два** Rust-сиблинга:
+
+- `foo_with_callback(..., F)` — синхронная регистрация; ваше замыкание
+  вызывается, когда Telegram присылает результат. Используйте, когда нельзя
+  `.await` (например, внутри не-async замыкания).
+- `async fn foo(...)` — возвращает естественный Rust-тип через `.await`.
+  Предпочтительно в продакшене.
+
+```rust,no_run
+use telegram_webapp_sdk::webapp::TelegramWebApp;
+
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+
+let confirmed: bool = app.show_confirm("Отправить заказ?").await?;
+let scanned: String = app.show_scan_qr_popup("Сканируйте QR-код").await?;
+let granted: bool = app.request_write_access().await?;
+let _ = (confirmed, scanned, granted);
+# Ok(())
+# }
+```
+
+То же справедливо для `share_message`, `request_chat`,
+`check_home_screen_status`, `set_emoji_status`, `request_emoji_status_access`,
+`open_invoice`, `download_file`, `read_text_from_clipboard`, `show_popup` и
+`invoke_custom_method`.
+
+## Кнопки
+
+Нижние кнопки Main и Secondary используют enum-селектор `BottomButton`
+(`BottomButton::Main` / `BottomButton::Secondary`):
+
+```rust,no_run
+use telegram_webapp_sdk::webapp::{BottomButton, BottomButtonParams, TelegramWebApp};
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+
+app.set_bottom_button_text(BottomButton::Main, "Отправить")?;
+app.show_bottom_button(BottomButton::Main)?;
+
+// Атомарное обновление через setParams:
+let params = BottomButtonParams {
+    text: Some("Отправить"),
+    color: Some("#2481cc"),
+    text_color: Some("#ffffff"),
+    is_active: Some(true),
+    is_visible: Some(true),
+    icon_custom_emoji_id: Some("123456789"), // Bot API 9.5+
+    ..Default::default()
+};
+app.set_bottom_button_params(BottomButton::Main, &params)?;
+# Ok(())
+# }
+```
+
+Есть удобные алиасы для главной кнопки (`set_main_button_text`,
+`show_main_button`, `enable_main_button`, `set_main_button_callback`, …) и для
+вторичной (`set_secondary_button_text`, `show_secondary_button`, …).
+
+Кнопки Back и Settings управляются напрямую:
+
+```rust,no_run
+# use telegram_webapp_sdk::webapp::TelegramWebApp;
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+app.show_back_button()?;
+let handle = app.set_back_button_callback(|| { /* назад */ })?;
+app.remove_back_button_callback(handle)?;
+
+app.show_settings_button()?;
+let sh = app.set_settings_button_callback(|| { /* настройки */ })?;
+app.remove_settings_button_callback(sh)?;
+# Ok(())
+# }
+```
+
+## Диалоги
+
+```rust,no_run
+# use telegram_webapp_sdk::webapp::TelegramWebApp;
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+app.show_alert("Сохранено!")?;
+let ok: bool = app.show_confirm("Удалить элемент?").await?;
+let button_id: String = app.show_popup(&wasm_bindgen::JsValue::NULL).await?;
+let code: String = app.show_scan_qr_popup("Наведите на QR-код").await?;
+app.close_scan_qr_popup()?;
+let _ = (ok, button_id, code);
+# Ok(())
+# }
+```
+
+## Навигация и ссылки
+
+`open_link` (с опциональным `OpenLinkOptions`), `open_telegram_link`,
+`switch_inline_query`, `share_url`, `share_message` / `share_to_story`,
+`request_chat`, `add_to_home_screen` и `check_home_screen_status`.
+
+## Тема и цвета
+
+`set_header_color`, `set_background_color`, `set_bottom_bar_color`,
+`color_scheme()`, а также свободная функция
+`telegram_webapp_sdk::api::theme::get_theme_params()`, возвращающая разобранную
+палитру.
+
+## Вьюпорт и safe-area
+
+`viewport_height()`, `viewport_width()`, `viewport_stable_height()`,
+`expand_viewport()` и аксессоры `SafeAreaInset`: `safe_area_inset()` /
+`content_safe_area_inset()`. Полноэкранный режим и ориентация:
+`request_fullscreen`, `exit_fullscreen`, `is_fullscreen`, `lock_orientation` и
+`unlock_orientation`.
+
+## Хранилища
+
+- **CloudStorage** — `api::cloud_storage::{get_item, set_item, remove_item, get_items, remove_items, get_keys}` (каждая возвращает JS `Promise`).
+- **DeviceStorage** — `api::device_storage::{set, get, remove, clear}` (`async`).
+- **SecureStorage** — `api::secure_storage::{set, get, restore, remove, clear}` (`async`).
+
+```rust,no_run
+use telegram_webapp_sdk::api::device_storage::{get, set};
+# async fn run() -> Result<(), wasm_bindgen::JsValue> {
+set("theme", "dark").await?;
+let value: Option<String> = get("theme").await?;
+let _ = value;
+# Ok(())
+# }
+```
+
+## Сенсоры
+
+Акселерометр, гироскоп и ориентация устройства предоставляют `start()`,
+`stop()`, геттер (`get_acceleration()`, `get_angular_velocity()`,
+`get_orientation()`) и колбэки жизненного цикла `on_started` / `on_changed` /
+`on_stopped` / `on_failed`. LocationManager: `init()`, `get_location()`,
+`open_settings()`, `on_location_manager_updated` и `on_location_requested`.
+
+```rust,no_run
+use telegram_webapp_sdk::api::accelerometer::{get_acceleration, start, stop};
+start()?;
+let reading = get_acceleration();
+stop()?;
+let _ = reading;
+# Ok::<(), wasm_bindgen::JsValue>(())
+```
+
+## Биометрия
+
+`api::biometric::{init, is_biometric_available, request_access, authenticate, update_biometric_token, open_settings, is_inited, is_access_granted, device_id, …}`.
+
+```rust,no_run
+use telegram_webapp_sdk::api::biometric::{authenticate, init, is_biometric_available, request_access};
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+init()?;
+if is_biometric_available()? {
+    request_access("auth-key", Some("Разблокировать хранилище"), None)?;
+    authenticate("auth-key", None, None)?;
+}
+# Ok(())
+# }
+```
+
+## Тактильная отдача
+
+```rust,no_run
+use telegram_webapp_sdk::api::haptic::{
+    impact_occurred, notification_occurred, selection_changed,
+    HapticImpactStyle, HapticNotificationType,
+};
+impact_occurred(HapticImpactStyle::Light)?;
+notification_occurred(HapticNotificationType::Success)?;
+selection_changed()?;
+# Ok::<(), wasm_bindgen::JsValue>(())
+```
+
+См. также [Интеграция с фреймворками](Интеграция) — реактивные обёртки над
+событиями вьюпорта, темы и safe-area.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,43 @@
+## 🌐 Language
+
+[🇬🇧 English](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Home-en) | [🇷🇺 Русский](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Главная)
+
+---
+
+## 🇬🇧 English
+
+**[Home](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Home-en)**
+
+**Getting Started**
+- [Installation](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Installation-en)
+- [Quick Start](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Quick-Start-en)
+
+**Guide**
+- [WebApp API](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/WebApp-API-en)
+- [Framework Integration](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Framework-Integration-en)
+- [Mock & Testing](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Testing-en)
+- [Examples](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Examples-en)
+
+---
+
+## 🇷🇺 Русский
+
+**[Главная](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Главная)**
+
+**Начало работы**
+- [Установка](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Установка)
+- [Быстрый старт](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Быстрый-старт)
+
+**Руководство**
+- [WebApp API](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/WebApp-API-ru)
+- [Интеграция с фреймворками](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Интеграция)
+- [Мок и тестирование](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Тестирование)
+- [Примеры](https://github.com/RAprogramm/telegram-webapp-sdk/wiki/Примеры)
+
+---
+
+## 📚 Reference
+
+- [API Docs](https://docs.rs/telegram-webapp-sdk)
+- [Crates.io](https://crates.io/crates/telegram-webapp-sdk)
+- [GitHub](https://github.com/RAprogramm/telegram-webapp-sdk)

--- a/wiki/Быстрый-старт.md
+++ b/wiki/Быстрый-старт.md
@@ -1,0 +1,110 @@
+# Быстрый старт
+
+Эта страница проходит через минимальное полезное Mini App: инициализация SDK,
+получение инстанса WebApp, сигнал готовности, чтение данных запуска и показ
+MainButton.
+
+## 1. Инициализация SDK и получение инстанса
+
+`init_sdk()` разбирает `initData` и `themeParams` из `Telegram.WebApp` и
+сохраняет их в глобальном контексте. После этого получите живой хендл WebApp.
+
+Есть два аксессора:
+
+- `TelegramWebApp::instance()` возвращает `Option<TelegramWebApp>` (`None`, если
+  код запущен не внутри Telegram) — удобно для graceful degradation.
+- `TelegramWebApp::try_instance()` возвращает `Result<TelegramWebApp, JsValue>`
+  — удобно внутри функций, использующих `?`.
+
+```rust,ignore
+use telegram_webapp_sdk::{core::init::init_sdk, webapp::TelegramWebApp};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn main() -> Result<(), JsValue> {
+    init_sdk()?;
+
+    let app = TelegramWebApp::try_instance()?;
+    app.ready()?;   // сообщаем Telegram, что интерфейс инициализирован
+    app.expand()?;  // разворачиваем Mini App на полную высоту
+
+    Ok(())
+}
+```
+
+Если нужен запуск без паники, используйте `try_init_sdk()` — он возвращает
+`Ok(false)`, когда Telegram недоступен:
+
+```rust,ignore
+use telegram_webapp_sdk::core::init::try_init_sdk;
+
+match try_init_sdk() {
+    Ok(true) => { /* запущено внутри Telegram */ }
+    Ok(false) => { /* обычный браузер — используем фолбэк */ }
+    Err(e) => eprintln!("ошибка инициализации: {e}")
+}
+```
+
+## 2. Чтение init data и пользователя
+
+Разобранные данные запуска лежат в глобальном `TelegramContext`. Доступ — через
+геттер на основе замыкания:
+
+```rust,ignore
+use telegram_webapp_sdk::core::context::TelegramContext;
+
+TelegramContext::get(|ctx| {
+    if let Some(user) = &ctx.init_data.user {
+        web_sys::console::log_1(&format!("Привет, {}", user.first_name).into());
+    }
+    let _ = ctx.init_data.auth_date;
+    let _ = ctx.init_data.start_param.as_deref();
+});
+```
+
+Для серверной проверки подписи возьмите сырую URL-кодированную строку и
+отправьте её на бэкенд (проверяйте там, с токеном бота — никогда на клиенте):
+
+```rust,ignore
+use telegram_webapp_sdk::TelegramWebApp;
+
+let raw_init_data = TelegramWebApp::get_raw_init_data()?;
+// POST /auth  { "init_data": raw_init_data }
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## 3. Минимальный MainButton
+
+Задайте подпись, покажите кнопку и зарегистрируйте колбэк клика. Колбэк
+возвращает `EventHandle`, который позже можно передать в
+`remove_main_button_callback`.
+
+```rust,ignore
+use telegram_webapp_sdk::webapp::TelegramWebApp;
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let app = TelegramWebApp::try_instance()?;
+
+app.set_main_button_text("Отправить заказ")?;
+app.set_main_button_color("#2481cc")?;
+app.enable_main_button()?;
+app.show_main_button()?;
+
+let handle = app.set_main_button_callback(|| {
+    if let Some(app) = TelegramWebApp::instance() {
+        let _ = app.send_data("order-confirmed");
+    }
+})?;
+
+// позже, когда кнопка больше не нужна:
+app.remove_main_button_callback(handle)?;
+app.hide_main_button()?;
+# Ok(())
+# }
+```
+
+## Что дальше
+
+- [WebApp API](WebApp-API-ru) — полная покрытая поверхность: диалоги, хранилища, сенсоры
+- [Интеграция с фреймворками](Интеграция) — реактивные хуки и компоненты кнопок для Leptos/Yew
+- [Мок и тестирование](Тестирование) — запуск этого кода вне Telegram

--- a/wiki/Главная.md
+++ b/wiki/Главная.md
@@ -1,0 +1,58 @@
+# Главная
+
+`telegram-webapp-sdk` — это типобезопасная и эргономичная обёртка на Rust/WASM
+над JavaScript API [Telegram Web Apps](https://core.telegram.org/bots/webapps).
+Она позволяет писать Telegram Mini Apps полностью на Rust: на чистом
+WebAssembly или через готовые интеграции с [Yew](https://yew.rs) и
+[Leptos](https://leptos.dev).
+
+## Покрытие API
+
+Крейт отслеживает **версию Telegram WebApp API 9.6** — это последняя версия
+Mini App, доступная в `telegram-web-app.js`. Bot API с тех пор дошёл до 10.1, но
+версии с 9.7 по 10.1 не добавили новых методов, полей или событий WebApp,
+поэтому покрытие полное. Bot API 9.5 добавил `icon_custom_emoji_id` для нижних
+кнопок; 9.6 добавил `WebApp.requestChat` и события `requestedChatSent` /
+`requestedChatFailed` — всё реализовано.
+
+Покрытая поверхность включает:
+
+- Кнопки: Main, Secondary, Back и Settings
+- Диалоги: alert, confirm, popup и сканер QR-кодов
+- Навигацию, ссылки, шеринг и инвойсы
+- Тему, цвета, вьюпорт и safe-area отступы
+- Хранилища: CloudStorage, DeviceStorage и SecureStorage
+- Сенсоры: акселерометр, гироскоп, ориентацию устройства и LocationManager
+- Биометрическую аутентификацию и тактильную отдачу
+
+Полный чек-лист по методам — в файле
+[`WEBAPP_API.md`](https://github.com/RAprogramm/telegram-webapp-sdk/blob/main/WEBAPP_API.md).
+
+## Флаги фич
+
+По умолчанию фичи не включены (`default = []`) — подключайте только нужное.
+
+| Фича     | Что включает |
+|----------|--------------|
+| `macros` | `telegram_app!`, `telegram_page!` и `telegram_router!` для приложений и роутинга без бойлерплейта |
+| `yew`    | `use_telegram_context`, реактивные хуки `use_viewport` / `use_theme` / `use_safe_area` и компоненты `BottomButton` / `BackButton` / `SettingsButton` |
+| `leptos` | `provide_telegram_context`, те же реактивные хуки `use_*` и аналогичные компоненты для Leptos |
+| `mock`   | Настраиваемый мок `Telegram.WebApp` для локальной разработки и тестов |
+| `full`   | Объединяет `macros`, `yew`, `leptos` и `mock` |
+
+```toml
+telegram-webapp-sdk = { version = "0.11", features = ["leptos", "mock"] }
+```
+
+## Оглавление документации
+
+- [Установка](Установка) — строка зависимости, флаги фич, MSRV и цель wasm32
+- [Быстрый старт](Быстрый-старт) — получение инстанса WebApp, `ready()`/`expand()`, чтение init data и минимальный MainButton
+- [WebApp API](WebApp-API-ru) — обзор покрытой поверхности по разделам и паттерн `*_with_callback` против `async`
+- [Интеграция с фреймворками](Интеграция) — хуки и компоненты для Leptos и Yew
+- [Мок и тестирование](Тестирование) — фича `mock` и `wasm_bindgen_test`
+- [Примеры](Примеры) — демо-приложение, vanilla, бот и полноценная интеграция
+
+## Лицензия
+
+`telegram-webapp-sdk` распространяется под лицензией MIT.

--- a/wiki/Интеграция.md
+++ b/wiki/Интеграция.md
@@ -1,0 +1,156 @@
+# Интеграция с фреймворками
+
+Крейт поставляет опциональные интеграции для [Leptos](https://leptos.dev) (фича
+`leptos`) и [Yew](https://yew.rs) (фича `yew`). Обе предоставляют одни и те же
+три реактивных хука и три компонента системных кнопок. Хуки инициализируются
+текущими значениями и перерисовывают компонент, когда Telegram присылает события
+`viewportChanged`, `themeChanged`, `safeAreaChanged` или
+`contentSafeAreaChanged`. Подписки очищаются автоматически при размонтировании /
+уничтожении скоупа.
+
+## Leptos
+
+Предоставьте контекст один раз рядом с корнем, затем читайте через
+`use_context`:
+
+```rust,ignore
+use leptos::prelude::*;
+use telegram_webapp_sdk::{core::context::TelegramContext, leptos::provide_telegram_context};
+
+#[component]
+fn App() -> impl IntoView {
+    provide_telegram_context().expect("context");
+    let ctx = use_context::<TelegramContext>().expect("context");
+    view! { <span>{ ctx.init_data.auth_date }</span> }
+}
+```
+
+### Реактивные хуки
+
+В Leptos хуки возвращают `ReadSignal<T>`, поэтому читайте их через `.get()`
+внутри замыкания:
+
+```rust,ignore
+use leptos::prelude::*;
+use telegram_webapp_sdk::leptos::{use_safe_area, use_theme, use_viewport};
+
+#[component]
+fn Status() -> impl IntoView {
+    let viewport = use_viewport(); // ReadSignal<ViewportState>
+    let theme = use_theme();       // ReadSignal<ThemeState>
+    let safe = use_safe_area();    // ReadSignal<SafeAreaState>
+    view! {
+        <div>
+            { move || viewport.get().height }
+            { move || theme.get().color_scheme.unwrap_or_default() }
+            { move || safe.get().area.map(|i| i.top).unwrap_or(0.0) }
+        </div>
+    }
+}
+```
+
+`ViewportState` содержит `height`, `stable_height` и `is_expanded`. `ThemeState`
+содержит `color_scheme: Option<String>` и разобранную палитру `params`.
+`SafeAreaState` содержит `area` и `content` как `Option<SafeAreaInset>`.
+
+### Компоненты
+
+`BottomButton` принимает селектор `button` и реактивный `text` (и опциональные
+`color` / `text_color` / `on_click`). `BackButton` и `SettingsButton` принимают
+реактивный сигнал `visible` и опциональное замыкание `on_click`. Все три
+управляют нативными кнопками Telegram и очищаются при размонтировании.
+
+```rust,ignore
+use leptos::prelude::*;
+use telegram_webapp_sdk::{
+    leptos::{provide_telegram_context, BackButton, BottomButton, SettingsButton},
+    webapp::BottomButton as Btn,
+};
+
+#[component]
+fn App() -> impl IntoView {
+    provide_telegram_context().expect("context");
+    let (text, _set_text) = signal("Отправить".to_owned());
+    let visible = RwSignal::new(true);
+    view! {
+        <BottomButton button=Btn::Main text on_click=move || { /* отправка */ } />
+        <BackButton visible=visible on_click=move || { /* назад */ } />
+        <SettingsButton visible=visible on_click=move || { /* настройки */ } />
+    }
+}
+```
+
+## Yew
+
+Читайте контекст хуком `use_telegram_context`. Он возвращает
+`Result<TelegramContext, JsValue>` и реактивно резолвится, как только контекст
+инициализирован:
+
+```rust,ignore
+use telegram_webapp_sdk::yew::use_telegram_context;
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    match use_telegram_context() {
+        Ok(ctx) => html! { <span>{ ctx.init_data.auth_date }</span> },
+        Err(_) => html! { <div>{ "Загрузка контекста Telegram..." }</div> },
+    }
+}
+```
+
+### Реактивные хуки
+
+В Yew хуки возвращают значение состояния напрямую (не сигнал), поэтому читайте
+поля прямо с него:
+
+```rust,ignore
+use telegram_webapp_sdk::yew::{use_safe_area, use_theme, use_viewport};
+use yew::prelude::*;
+
+#[function_component(Status)]
+fn status() -> Html {
+    let viewport = use_viewport(); // ViewportState
+    let theme = use_theme();       // ThemeState
+    let safe = use_safe_area();    // SafeAreaState
+    html! {
+        <div>
+            { viewport.height }
+            { theme.color_scheme.clone().unwrap_or_default() }
+            { safe.area.map(|i| i.top).unwrap_or(0.0) }
+        </div>
+    }
+}
+```
+
+### Компоненты
+
+Компоненты Yew принимают обычные пропсы: `BottomButton` использует `text` /
+`color` / `text_color` / `on_click` (всегда управляет кнопкой Main), а
+`BackButton` и `SettingsButton` принимают проп `visible: bool` и
+`on_click: Callback<()>`.
+
+```rust,ignore
+use telegram_webapp_sdk::yew::{BackButton, BottomButton, SettingsButton};
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    let on_main = Callback::from(|_| {});
+    let on_back = Callback::from(|_| {});
+    let on_settings = Callback::from(|_| {});
+    html! {
+        <>
+            <BottomButton text="Отправить" color="#000" text_color="#fff" on_click={on_main} />
+            <BackButton visible={true} on_click={on_back} />
+            <SettingsButton visible={true} on_click={on_settings} />
+        </>
+    }
+}
+```
+
+## См. также
+
+- [Быстрый старт](Быстрый-старт) — vanilla-подход без фреймворка
+- [Мок и тестирование](Тестирование) — рендер компонентов против мока
+- [Примеры](Примеры) — запускаемое демо на Trunk

--- a/wiki/Примеры.md
+++ b/wiki/Примеры.md
@@ -1,0 +1,89 @@
+# Примеры
+
+В репозитории есть несколько запускаемых примеров, встроенных в Cargo-воркспейс.
+Каждый показывает свой стиль интеграции — от полноценного Mini App на Trunk до
+обычного WASM-бинарника и серверной части полного стека.
+
+## `demo/` — WASM-приложение на Trunk
+
+Полноценное Mini App, собранное с фичами `macros` и `mock`. Использует
+`telegram_page!` / `telegram_router!` для роутинга и включает компоненты и
+страницы (`demo/src/components`, `demo/src/pages`). Так как включена фича `mock`,
+демо работает в обычном браузере во время разработки.
+
+```bash
+cd demo
+trunk serve        # dev-сервер с автоперезагрузкой на http://localhost:8080
+trunk build --release
+```
+
+Файл `demo/index.html` загружает `telegram-web-app.js` от Telegram и собранный
+Trunk WASM-бандл.
+
+## `examples/vanilla` — без фреймворка
+
+Пример на чистом WebAssembly (`examples/vanilla/src/main.rs` + `ui.rs`),
+использующий SDK и DOM-хелперы напрямую, без Yew и Leptos. Зависит от крейта с
+фичей `mock`, поэтому запускается самостоятельно. Хорошая отправная точка, если
+нужен полный контроль над DOM.
+
+```bash
+cd examples/vanilla
+trunk serve
+```
+
+## `examples/bots/rust_bot` — Telegram-бот
+
+Бот на [teloxide](https://github.com/teloxide/teloxide)
+(`examples/bots/rust_bot`), который открывает демо Mini App через WebApp-кнопки и
+принимает заказы, отправленные из приложения через `sendData`. Это серверная
+часть — нативный бинарник, не WASM.
+
+```bash
+cd examples/bots/rust_bot
+cp .env.example .env          # добавьте свой TELOXIDE_TOKEN
+cargo run
+```
+
+Требуется токен бота от [@BotFather](https://t.me/BotFather) и URL WebApp по
+HTTPS.
+
+## `examples/integration` — полный стек
+
+Пример из двух частей, показывающий round-trip фронтенд↔бэкенд:
+
+- `examples/integration/frontend` — WASM Mini App, отправляющее JSON-сообщение
+  боту через `TelegramWebApp::send_data(...)`. (Этот член исключён из воркспейса
+  и собирается отдельно через Trunk.)
+- `examples/integration/backend` — бот на teloxide, принимающий `web_app_data`
+  из обновления, разбирающий JSON и отвечающий.
+
+```bash
+# терминал 1 — бэкенд
+cd examples/integration/backend
+cargo run
+
+# терминал 2 — фронтенд
+cd examples/integration/frontend
+trunk serve
+```
+
+Поток данных: пользователь открывает Mini App → взаимодействует с UI →
+приложение вызывает `send_data` → Telegram доставляет payload боту как
+`web_app_data` → бот обрабатывает его и отвечает.
+
+## Сборка любого WASM-примера
+
+Все браузерные примеры собираются под `wasm32-unknown-unknown` и обслуживаются
+через Trunk:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install trunk
+```
+
+## См. также
+
+- [Быстрый старт](Быстрый-старт) — минимальная версия vanilla-примера
+- [Интеграция с фреймворками](Интеграция) — паттерны Leptos/Yew из демо
+- [Мок и тестирование](Тестирование) — фича `mock`, позволяющая запускать эти примеры вне Telegram

--- a/wiki/Тестирование.md
+++ b/wiki/Тестирование.md
@@ -1,0 +1,124 @@
+# Мок и тестирование
+
+Фича `mock` устанавливает настраиваемый поддельный объект `Telegram.WebApp` на
+`window`, что позволяет разрабатывать и тестировать вне клиента Telegram.
+Включите её:
+
+```toml
+telegram-webapp-sdk = { version = "0.11", features = ["mock"] }
+```
+
+## Установка мок-окружения
+
+Мок находится в `telegram_webapp_sdk::mock`. Соберите `MockTelegramConfig` (он
+реализует `Default`) и вызовите `mock_telegram_webapp` — он внедрит
+`window.Telegram.WebApp` с замоканными `initData`, `themeParams`, `platform` и
+`version`. Используйте только в debug-сборках.
+
+```rust,ignore
+use telegram_webapp_sdk::mock::{config::MockTelegramConfig, init::mock_telegram_webapp};
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let config = MockTelegramConfig::default();
+mock_telegram_webapp(config)?;
+// window.Telegram.WebApp теперь существует — SDK ведёт себя как внутри Telegram.
+# Ok(())
+# }
+```
+
+### Настройка замоканных данных
+
+`MockTelegramConfig` содержит опциональные поля для пользователя, данных
+авторизации, всех цветов темы и платформы/версии. Замоканный пользователь — это
+`MockTelegramUser`:
+
+```rust,ignore
+use telegram_webapp_sdk::mock::{
+    config::MockTelegramConfig, data::MockTelegramUser, init::mock_telegram_webapp,
+};
+
+# fn run() -> Result<(), wasm_bindgen::JsValue> {
+let config = MockTelegramConfig {
+    user: Some(MockTelegramUser {
+        id: 42,
+        first_name: "Alice".into(),
+        username: Some("alice".into()),
+        language_code: Some("en".into()),
+        ..Default::default()
+    }),
+    platform: Some("android".into()),
+    version: Some("9.6".into()),
+    ..Default::default()
+};
+mock_telegram_webapp(config)?;
+# Ok(())
+# }
+```
+
+Конфиг можно также загрузить из TOML-файла (тот же `telegram-webapp.toml`,
+который `telegram_app!` читает в debug-сборках):
+
+```rust,ignore
+use telegram_webapp_sdk::mock::config::MockTelegramConfig;
+
+let config = MockTelegramConfig::from_file("telegram-webapp.toml")?;
+# Ok::<(), std::io::Error>(())
+```
+
+## Тестирование через `wasm_bindgen_test`
+
+Поскольку SDK работает с глобальными объектами браузера, тесты выполняются в
+headless-браузере через `wasm-bindgen-test`. Добавьте его в dev-зависимости:
+
+```toml
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+```
+
+Настройте тесты на запуск в браузере и установите мок перед использованием SDK:
+
+```rust,ignore
+use telegram_webapp_sdk::{
+    core::init::init_sdk,
+    mock::{config::MockTelegramConfig, init::mock_telegram_webapp},
+    webapp::TelegramWebApp,
+};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn instance_is_available_after_mock() {
+    mock_telegram_webapp(MockTelegramConfig::default()).expect("mock installed");
+    init_sdk().expect("sdk initialized");
+
+    let app = TelegramWebApp::instance().expect("instance");
+    app.ready().expect("ready");
+}
+```
+
+Запуск набора тестов на реальном браузерном движке:
+
+```bash
+# Chrome / Chromium
+wasm-pack test --headless --chrome
+
+# или Firefox
+wasm-pack test --headless --firefox
+```
+
+## Советы
+
+- В коде приложения предпочитайте `TelegramWebApp::instance()` (возвращает
+  `Option`), чтобы один и тот же бинарь корректно деградировал, когда нет ни
+  Telegram, ни мока.
+- Все `wasm_bindgen_test` разделяют один `window`; устанавливайте мок в начале
+  каждого теста, которому он нужен, а не полагайтесь на порядок выполнения.
+- Учтите, что `TelegramContext::init` успешно отрабатывает только один раз на
+  поток — проектируйте тесты так, чтобы они не зависели от повторной
+  инициализации глобального контекста.
+
+## См. также
+
+- [Быстрый старт](Быстрый-старт) — код, который вы тестируете
+- [Примеры](Примеры) — `examples/vanilla` собирается с фичей `mock`

--- a/wiki/Установка.md
+++ b/wiki/Установка.md
@@ -1,0 +1,91 @@
+# Установка
+
+## Добавление зависимости
+
+Добавьте крейт в `Cargo.toml`:
+
+```toml
+[dependencies]
+telegram-webapp-sdk = "0.11"
+```
+
+## Включение флагов фич
+
+Крейт поставляется **без включённых фич** (`default = []`), поэтому вы явно
+подключаете только нужное:
+
+```toml
+telegram-webapp-sdk = { version = "0.11", features = ["macros", "yew", "leptos", "mock"] }
+```
+
+| Фича     | Назначение |
+|----------|-----------|
+| `macros` | Макросы `telegram_app!`, `telegram_page!` и `telegram_router!` |
+| `yew`    | Хук контекста, реактивные хуки и компоненты системных кнопок для Yew |
+| `leptos` | Провайдер контекста, реактивные хуки и компоненты системных кнопок для Leptos |
+| `mock`   | Настраиваемый мок `Telegram.WebApp` для локальной разработки |
+| `full`   | Сокращение для `macros` + `yew` + `leptos` + `mock` |
+
+Обычно включают один фреймворк плюс `mock`:
+
+```toml
+# Приложение на Leptos с поддержкой локального мока
+telegram-webapp-sdk = { version = "0.11", features = ["leptos", "mock"] }
+```
+
+## Минимальная поддерживаемая версия Rust
+
+MSRV — **Rust 1.96** (edition 2024). Более старые тулчейны не поддерживаются.
+
+```bash
+rustup update stable
+rustc --version   # должно быть >= 1.96
+```
+
+## Цель сборки — браузер
+
+Telegram Mini Apps исполняются как WebAssembly во встроенном браузере Telegram,
+поэтому собирайте под цель `wasm32-unknown-unknown`:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+## Сборка через Trunk или wasm-pack
+
+Используйте WASM-бандлер, чтобы получить итоговый `.wasm`, JS-обвязку и
+`index.html`.
+
+**Trunk** (рекомендуется для целых приложений — его использует демо):
+
+```bash
+cargo install trunk
+trunk serve   # dev-сервер с автоперезагрузкой
+trunk build --release
+```
+
+Минимальный `index.html` для Trunk подключает скрипт Telegram и ваш крейт:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <link data-trunk rel="rust" />
+  </head>
+  <body></body>
+</html>
+```
+
+**wasm-pack** (для библиотек или интеграции, управляемой из JS):
+
+```bash
+cargo install wasm-pack
+wasm-pack build --target web
+```
+
+## Дальше
+
+- [Быстрый старт](Быстрый-старт) — инициализация SDK и первая кнопка
+- [Интеграция с фреймворками](Интеграция) — подключение Leptos или Yew
+- [Мок и тестирование](Тестирование) — запуск вне Telegram при разработке


### PR DESCRIPTION
Closes #246

Adds a multilingual (EN + RU) documentation site published to GitHub Pages, mirroring the setup in RAprogramm/entity-derive.

## Contents
- `wiki/` — 7 English + 7 Russian pages (Home, Installation, Quick Start, WebApp API, Framework Integration, Mock & Testing, Examples) plus `_Sidebar.md`. Code samples verified against the real crate API.
- `site/build.py` + `site/landing.html` — mdBook-based multilingual builder (one book per language + landing page), adapted for this crate (repo URL, EN/RU, logo).
- `.github/workflows/site.yml` — build with mdBook and deploy to Pages (actions SHA-pinned).
- `.github/workflows/wiki.yml` — sync `wiki/` to the GitHub Wiki (SHA-pinned).
- `.gitignore` — ignore `__pycache__/`.

## Setup done
- GitHub Pages enabled with the GitHub Actions source; repo homepage set to https://raprogramm.github.io/telegram-webapp-sdk/.

## Notes
- The site builds cleanly locally (mdBook 0.5, both books + landing + logo).
- `wiki.yml` needs the wiki initialized once (create any page in the UI) before its first push can succeed.
- Follow-up: README advertises a mock API (`mock::MockConfig`, `mock::install`) that does not exist; the wiki documents the real API (`mock::config::MockTelegramConfig`, `mock::init::mock_telegram_webapp`). README should be corrected separately.