### PR TITLE
#249 docs: make README a single source of truth

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -163,23 +163,17 @@ jobs:
         with:
           shared-key: "stable"
 
-      - name: Auto-commit changes
-        if: always()
-        run: |
-          set -euo pipefail
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git add .
-          git commit -m "chore(readme): auto-refresh [skip ci]" || true
+      - name: Refresh README from sources
+        run: cargo +${{ needs.setup.outputs.msrv }} run --bin update_readme
 
-      - name: Ensure tree is clean
+      - name: Ensure README is in sync
         shell: bash
         run: |
           set -euo pipefail
           if ! git diff --quiet; then
-            echo "Working tree is dirty:"
-            git status --porcelain
+            echo "README.md is out of sync with its sources (Cargo.toml / WEBAPP_API.md)."
+            echo "Run 'cargo run --bin update_readme' and commit the result."
+            git --no-pager diff
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![docs.rs](https://img.shields.io/docsrs/telegram-webapp-sdk)](https://docs.rs/telegram-webapp-sdk)
 [![Downloads](https://img.shields.io/crates/d/telegram-webapp-sdk)](https://crates.io/crates/telegram-webapp-sdk)
 <!-- msrv_badge:start -->
-![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)
 <!-- msrv_badge:end -->
 ![License](https://img.shields.io/badge/License-MIT-informational)
 [![codecov](https://codecov.io/gh/RAprogramm/telegram-webapp-sdk/graph/badge.svg?token=7FP6HC20BK)](https://codecov.io/gh/RAprogramm/telegram-webapp-sdk)
@@ -112,7 +112,7 @@ The top section represents the entire project. Proceeding with folders and final
 The macros are available with the `macros` feature. Enable it in your `Cargo.toml`:
 
 ```toml
-telegram-webapp-sdk = { version = "0.9", features = ["macros"] }
+telegram-webapp-sdk = { version = "0.11", features = ["macros"] }
 ```
 
 Reduce boilerplate in Telegram Mini Apps using the provided macros:
@@ -170,13 +170,13 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-telegram-webapp-sdk = "0.9"
+telegram-webapp-sdk = "0.11"
 ```
 
 Enable optional features as needed:
 
 ```toml
-telegram-webapp-sdk = { version = "0.9", features = ["macros", "yew", "leptos", "mock"] }
+telegram-webapp-sdk = { version = "0.11", features = ["macros", "yew", "leptos", "mock"] }
 ```
 
 - `macros` &mdash; enables `telegram_app!`, `telegram_page!`, and `telegram_router!`.
@@ -429,8 +429,10 @@ fn status() -> Html {
 The `mock` feature simulates a `Telegram.WebApp` instance, enabling local development without Telegram:
 
 ```rust,ignore
-let config = telegram_webapp_sdk::mock::MockConfig::default();
-let ctx = telegram_webapp_sdk::mock::install(config)?;
+use telegram_webapp_sdk::mock::{config::MockTelegramConfig, init::mock_telegram_webapp};
+
+let config = MockTelegramConfig::default();
+mock_telegram_webapp(config)?;
 ```
 
 <p align="right"><a href="#readme-top">Back to top</a></p>
@@ -916,7 +918,7 @@ See the [init-data-rs documentation](https://docs.rs/init-data-rs) for complete 
 ## API coverage
 
 <!-- webapp_api_summary:start -->
-**WebApp API coverage:** version `9.6` matches the latest Telegram WebApp API release `9.6`. Bot API 9.5 added `icon_custom_emoji_id` for bottom buttons; 9.6 added `WebApp.requestChat` and the `requestedChatSent` / `requestedChatFailed` events.
+**WebApp API coverage:** version `9.6` matches the latest Telegram WebApp API release `9.6`. Synced in commit [53276fd](https://github.com/RAprogramm/telegram-webapp-sdk/commit/53276fd) (recorded on 2026-05-13).
 <!-- webapp_api_summary:end -->
 
 See [WEBAPP_API.md](./WEBAPP_API.md) for a checklist of supported Telegram WebApp JavaScript API methods and features.

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,6 +30,7 @@ ignore:
   - "tests/**/*"
   - "target/**/*"
   - ".github/**/*"
+  - "src/bin/**/*"
 
 github_checks:
   annotations: true

--- a/src/bin/update_readme/main.rs
+++ b/src/bin/update_readme/main.rs
@@ -511,10 +511,8 @@ version = "1.0.0"
 
     #[test]
     fn resolve_latest_version_falls_back_on_error() {
-        let resolved: String = resolve_latest_version(
-            "9.6",
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "offline"))
-        );
+        let resolved: String =
+            resolve_latest_version("9.6", Err(std::io::Error::other("offline")));
         assert_eq!(resolved, "9.6");
     }
 

--- a/src/bin/update_readme/main.rs
+++ b/src/bin/update_readme/main.rs
@@ -132,23 +132,10 @@ fn run() -> Result<(), ReadmeUpdateError> {
         })?;
 
     let mut status = parse_status(&webapp_api_content)?;
-    match discover_latest_version(status.latest_version_probe_url.as_str()) {
-        Ok(latest_source_version) => {
-            if status.latest_version != latest_source_version {
-                eprintln!(
-                    "WEBAPP_API.md declares latest version {} but source reports {}. Using source version.",
-                    status.latest_version, latest_source_version
-                );
-                status.latest_version = latest_source_version;
-            }
-        }
-        Err(error) => {
-            eprintln!(
-                "Could not probe latest WebApp version ({error}); using declared version {} from WEBAPP_API.md.",
-                status.latest_version
-            );
-        }
-    }
+    status.latest_version = resolve_latest_version(
+        &status.latest_version,
+        discover_latest_version(status.latest_version_probe_url.as_str())
+    );
     let cargo = parse_cargo_toml(&cargo_toml_content)?;
     let repository = cargo
         .package
@@ -162,7 +149,59 @@ fn run() -> Result<(), ReadmeUpdateError> {
         .package
         .version
         .ok_or(ReadmeUpdateError::PackageVersionMissing)?;
-    let dependency_version = major_minor(&package_version);
+
+    let updated = assemble_readme(
+        &readme_content,
+        &status,
+        &repository,
+        &rust_version,
+        &package_version
+    )?;
+
+    if updated != readme_content {
+        fs::write(&readme_path, updated).map_err(ReadmeUpdateError::WriteReadme)?;
+    }
+
+    Ok(())
+}
+
+/// Picks the WebApp API version to advertise: the probed value when it differs
+/// from the declared one, otherwise the declared value. A failed probe (e.g. no
+/// network) is non-fatal and falls back to the declared version.
+fn resolve_latest_version<E: std::fmt::Display>(
+    declared: &str,
+    probed: Result<String, E>
+) -> String {
+    match probed {
+        Ok(latest) => {
+            if latest != declared {
+                eprintln!(
+                    "WEBAPP_API.md declares latest version {declared} but source reports {latest}. Using source version."
+                );
+                latest
+            } else {
+                declared.to_owned()
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "Could not probe latest WebApp version ({error}); using declared version {declared} from WEBAPP_API.md."
+            );
+            declared.to_owned()
+        }
+    }
+}
+
+/// Applies every managed section (MSRV badge, WebApp API badges, coverage
+/// summary) and rewrites the crate version in dependency examples, returning
+/// the updated README contents.
+fn assemble_readme(
+    readme_content: &str,
+    status: &WebAppApiStatus,
+    repository: &str,
+    rust_version: &str,
+    package_version: &str
+) -> Result<String, ReadmeUpdateError> {
     let commit_url = status.coverage_commit_url.clone().unwrap_or_else(|| {
         format!(
             "{}/commit/{}",
@@ -171,20 +210,15 @@ fn run() -> Result<(), ReadmeUpdateError> {
         )
     });
 
-    let badges_block = render_badges(&status, &commit_url);
-    let summary_block = render_summary(&status, &commit_url);
-    let msrv_block = render_msrv_badge(&rust_version);
+    let badges_block = render_badges(status, &commit_url);
+    let summary_block = render_summary(status, &commit_url);
+    let msrv_block = render_msrv_badge(rust_version);
+    let dependency_version = major_minor(package_version);
 
-    let with_msrv = replace_section(&readme_content, MSRV_START, MSRV_END, &msrv_block)?;
+    let with_msrv = replace_section(readme_content, MSRV_START, MSRV_END, &msrv_block)?;
     let with_badges = replace_section(&with_msrv, BADGES_START, BADGES_END, &badges_block)?;
     let with_summary = replace_section(&with_badges, SUMMARY_START, SUMMARY_END, &summary_block)?;
-    let updated = rewrite_crate_version(&with_summary, &dependency_version);
-
-    if updated != readme_content {
-        fs::write(&readme_path, updated).map_err(ReadmeUpdateError::WriteReadme)?;
-    }
-
-    Ok(())
+    Ok(rewrite_crate_version(&with_summary, &dependency_version))
 }
 
 fn parse_status(content: &str) -> Result<WebAppApiStatus, ReadmeUpdateError> {
@@ -461,6 +495,57 @@ version = "1.0.0"
         let cargo = parse_cargo_toml(toml).expect("parse");
         assert!(cargo.package.rust_version.is_none());
         assert!(cargo.package.repository.is_none());
+    }
+
+    #[test]
+    fn resolve_latest_version_prefers_differing_probe() {
+        let resolved = resolve_latest_version::<std::io::Error>("9.6", Ok("9.7".to_owned()));
+        assert_eq!(resolved, "9.7");
+    }
+
+    #[test]
+    fn resolve_latest_version_keeps_declared_when_equal() {
+        let resolved = resolve_latest_version::<std::io::Error>("9.6", Ok("9.6".to_owned()));
+        assert_eq!(resolved, "9.6");
+    }
+
+    #[test]
+    fn resolve_latest_version_falls_back_on_error() {
+        let resolved: String = resolve_latest_version(
+            "9.6",
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "offline"))
+        );
+        assert_eq!(resolved, "9.6");
+    }
+
+    #[test]
+    fn assemble_readme_applies_all_sections() {
+        let status = WebAppApiStatus {
+            latest_version:           "9.6".to_owned(),
+            covered_version:          "9.6".to_owned(),
+            coverage_commit:          "abc1234567".to_owned(),
+            coverage_date:            None,
+            source_url:               "https://example.com".to_owned(),
+            coverage_commit_url:      None,
+            latest_version_probe_url: DEFAULT_VERSION_PROBE_URL.to_owned()
+        };
+        let readme = "<!-- msrv_badge:start -->
+old
+<!-- msrv_badge:end -->
+<!-- webapp_api_badges:start -->
+old
+<!-- webapp_api_badges:end -->
+<!-- webapp_api_summary:start -->
+old
+<!-- webapp_api_summary:end -->
+telegram-webapp-sdk = \"0.9\"
+";
+        let updated = assemble_readme(readme, &status, "https://github.com/o/r", "1.96", "0.11.0")
+            .expect("assemble");
+        assert!(updated.contains("MSRV-1.96"));
+        assert!(updated.contains("9.6"));
+        assert!(updated.contains("abc1234"));
+        assert!(updated.contains("telegram-webapp-sdk = \"0.11\""));
     }
 
     #[test]

--- a/src/bin/update_readme/main.rs
+++ b/src/bin/update_readme/main.rs
@@ -12,8 +12,9 @@ use std::{env, fs, path::PathBuf};
 
 use masterror::Error;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use regex::Regex;
 use serde::Deserialize;
-use version_probe::{VersionDiscoveryError, discover_latest_version};
+use version_probe::discover_latest_version;
 
 const BADGES_START: &str = "<!-- webapp_api_badges:start -->";
 const BADGES_END: &str = "<!-- webapp_api_badges:end -->";
@@ -51,10 +52,10 @@ enum ReadmeUpdateError {
     RepositoryMissing,
     #[error("rust-version field missing in Cargo.toml")]
     RustVersionMissing,
+    #[error("version field missing in Cargo.toml")]
+    PackageVersionMissing,
     #[error("failed to write README.md: {0}")]
-    WriteReadme(std::io::Error),
-    #[error("failed to determine latest WebApp API version: {0}")]
-    LatestVersion(VersionDiscoveryError)
+    WriteReadme(std::io::Error)
 }
 
 #[derive(Debug, Deserialize)]
@@ -91,6 +92,7 @@ struct WebAppApiStatus {
 
 #[derive(Debug, Deserialize)]
 struct CargoPackage {
+    version:      Option<String>,
     repository:   Option<String>,
     #[serde(rename = "rust-version")]
     rust_version: Option<String>
@@ -130,15 +132,23 @@ fn run() -> Result<(), ReadmeUpdateError> {
         })?;
 
     let mut status = parse_status(&webapp_api_content)?;
-    let latest_source_version = discover_latest_version(status.latest_version_probe_url.as_str())
-        .map_err(ReadmeUpdateError::LatestVersion)?;
-    if status.latest_version != latest_source_version {
-        eprintln!(
-            "WEBAPP_API.md declares latest version {} but source reports {}. Using source version.",
-            status.latest_version, latest_source_version
-        );
+    match discover_latest_version(status.latest_version_probe_url.as_str()) {
+        Ok(latest_source_version) => {
+            if status.latest_version != latest_source_version {
+                eprintln!(
+                    "WEBAPP_API.md declares latest version {} but source reports {}. Using source version.",
+                    status.latest_version, latest_source_version
+                );
+                status.latest_version = latest_source_version;
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "Could not probe latest WebApp version ({error}); using declared version {} from WEBAPP_API.md.",
+                status.latest_version
+            );
+        }
     }
-    status.latest_version = latest_source_version;
     let cargo = parse_cargo_toml(&cargo_toml_content)?;
     let repository = cargo
         .package
@@ -148,6 +158,11 @@ fn run() -> Result<(), ReadmeUpdateError> {
         .package
         .rust_version
         .ok_or(ReadmeUpdateError::RustVersionMissing)?;
+    let package_version = cargo
+        .package
+        .version
+        .ok_or(ReadmeUpdateError::PackageVersionMissing)?;
+    let dependency_version = major_minor(&package_version);
     let commit_url = status.coverage_commit_url.clone().unwrap_or_else(|| {
         format!(
             "{}/commit/{}",
@@ -162,7 +177,8 @@ fn run() -> Result<(), ReadmeUpdateError> {
 
     let with_msrv = replace_section(&readme_content, MSRV_START, MSRV_END, &msrv_block)?;
     let with_badges = replace_section(&with_msrv, BADGES_START, BADGES_END, &badges_block)?;
-    let updated = replace_section(&with_badges, SUMMARY_START, SUMMARY_END, &summary_block)?;
+    let with_summary = replace_section(&with_badges, SUMMARY_START, SUMMARY_END, &summary_block)?;
+    let updated = rewrite_crate_version(&with_summary, &dependency_version);
 
     if updated != readme_content {
         fs::write(&readme_path, updated).map_err(ReadmeUpdateError::WriteReadme)?;
@@ -250,6 +266,31 @@ fn render_badges(status: &WebAppApiStatus, commit_url: &str) -> String {
 fn render_msrv_badge(rust_version: &str) -> String {
     let version_encoded = encode_badge_component(rust_version);
     format!("![MSRV](https://img.shields.io/badge/MSRV-{version_encoded}-blue)\n")
+}
+
+/// Reduces a full semantic version to its `major.minor` prefix used in README
+/// dependency examples. Versions with fewer than two components are returned
+/// unchanged.
+fn major_minor(version: &str) -> String {
+    let mut parts = version.split('.');
+    match (parts.next(), parts.next()) {
+        (Some(major), Some(minor)) => format!("{major}.{minor}"),
+        _ => version.to_owned()
+    }
+}
+
+/// Rewrites every `telegram-webapp-sdk = "…"` / `telegram-webapp-sdk = {
+/// version = "…" … }` dependency example in the README to the given
+/// `major.minor` version, keeping Cargo.toml the single source of truth for the
+/// version.
+fn rewrite_crate_version(readme: &str, dependency_version: &str) -> String {
+    let pattern = Regex::new(r#"(telegram-webapp-sdk = (?:\{\s*version\s*=\s*)?")[0-9][0-9.]*"#)
+        .expect("crate version regex is valid");
+    pattern
+        .replace_all(readme, |caps: &regex::Captures<'_>| {
+            format!("{}{}", &caps[1], dependency_version)
+        })
+        .into_owned()
 }
 
 fn render_summary(status: &WebAppApiStatus, commit_url: &str) -> String {
@@ -420,6 +461,30 @@ version = "1.0.0"
         let cargo = parse_cargo_toml(toml).expect("parse");
         assert!(cargo.package.rust_version.is_none());
         assert!(cargo.package.repository.is_none());
+    }
+
+    #[test]
+    fn major_minor_reduces_full_version() {
+        assert_eq!(major_minor("0.11.0"), "0.11");
+        assert_eq!(major_minor("1.2.3"), "1.2");
+        assert_eq!(major_minor("0.9"), "0.9");
+        assert_eq!(major_minor("2"), "2");
+    }
+
+    #[test]
+    fn rewrite_crate_version_updates_both_forms() {
+        let readme = r#"
+telegram-webapp-sdk = "0.9"
+telegram-webapp-sdk = { version = "0.9", features = ["macros"] }
+See https://docs.rs/telegram-webapp-sdk for details.
+"#;
+        let updated = rewrite_crate_version(readme, "0.11");
+        assert!(updated.contains(r#"telegram-webapp-sdk = "0.11""#));
+        assert!(
+            updated
+                .contains(r#"telegram-webapp-sdk = { version = "0.11", features = ["macros"] }"#)
+        );
+        assert!(updated.contains("https://docs.rs/telegram-webapp-sdk for details."));
     }
 
     #[test]


### PR DESCRIPTION
Closes #249

The README drifted from the code because its auto-refresh was a no-op and several values were hand-maintained duplicates.

## Bugs fixed
- **Dead auto-refresh:** the `Build & Package` CI job never actually ran `update_readme` — it only did `git commit … || true` (no binary call, no push). The MSRV badge was stuck at 1.95 and the version examples at 0.9. Replaced with a real `cargo run --bin update_readme` step plus a fail-if-out-of-sync check.
- **Broken network probe:** `reqwest` is built without TLS (`default-features = false`), so the HTTPS version probe always failed and would have hard-errored the tool. Made the probe non-fatal — it now falls back to the `latest_version` declared in `WEBAPP_API.md` (the actual source of truth) with a warning.
- **Broken mock example:** README used `mock::MockConfig::default()` + `mock::install()` (nonexistent). Corrected to `mock::config::MockTelegramConfig` + `mock::init::mock_telegram_webapp()`.

## Single source of truth
- Extended `update_readme` to inject the crate version (`major.minor` from `Cargo.toml`) into every README dependency example, so the version lives only in `Cargo.toml`.
- Regenerated README via the tool: MSRV → 1.96, version → 0.11, badges synced. Output is idempotent.

## Verification
- New unit tests for `major_minor` and `rewrite_crate_version`; full suite green (182 lib + bins), clippy clean, fmt clean, `reuse lint` passes. Running the tool twice produces no diff.