### PR TITLE
#251 docs: build docs.rs with all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/telegram-webapp-sdk"
 keywords = ["telegram", "webapp", "wasm", "sdk"]
 categories = ["web-programming", "wasm"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [workspace.package]
 rust-version = "1.96"
 


### PR DESCRIPTION
Closes #251

The crate is `default = []`, so docs.rs built the published documentation with no features enabled — the `macros`, `yew`, `leptos`, and `mock` modules were absent from https://docs.rs/telegram-webapp-sdk.

Adds `[package.metadata.docs.rs] all-features = true` so docs.rs documents the full API surface. Verified locally with `cargo doc --all-features --no-deps` (builds clean). Default target retained because `reqwest` (a dependency) does not compile for wasm32.