### PR TITLE
#257 ci: run cargo-semver-checks in the release pipeline

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2
+        with:
+          tool: cargo-semver-checks
+
       - name: Run release-plz release
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5
         with:
@@ -65,6 +70,11 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2
+        with:
+          tool: cargo-semver-checks
 
       - name: Run release-plz release-pr
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5


### PR DESCRIPTION
Closes #257

release-plz uses `cargo-semver-checks` to detect API-breaking changes and choose the correct semver bump — but only when the tool is present in the runner. It wasn't installed, so a breaking change could ship under a minor/patch bump.

Installs `cargo-semver-checks` (SHA-pinned via taiki-e/install-action) before the release-plz steps in both jobs of `release-plz.yml`. Verified: YAML parses, `reuse lint` passes.