### PR TITLE
#259 docs: enforce missing_docs and document public API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,17 +1,37 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+//! Bindings for the individual Telegram WebApp JavaScript APIs.
+//!
+//! Each submodule wraps one area of the `Telegram.WebApp` interface, from
+//! sensor access and haptic feedback to storage, theming, and viewport
+//! information.
+
+/// Accelerometer sensor: three-axis acceleration readings.
 pub mod accelerometer;
+/// Biometric manager: fingerprint/face authentication and access requests.
 pub mod biometric;
+/// Cloud storage: per-user key-value storage synced across devices.
 pub mod cloud_storage;
+/// Device orientation sensor: orientation angles in degrees.
 pub mod device_orientation;
+/// Device storage: local key-value storage on the current device.
 pub mod device_storage;
+/// WebApp event subscription helpers (`onEvent`/`offEvent`).
 pub mod events;
+/// Gyroscope sensor: angular velocity readings.
 pub mod gyroscope;
+/// Haptic feedback: impact, notification, and selection vibrations.
 pub mod haptic;
+/// Location manager: initialization and geolocation access.
 pub mod location_manager;
+/// Secure storage: encrypted key-value storage that survives reinstalls.
 pub mod secure_storage;
+/// Settings button: control over the WebApp settings button.
 pub mod settings_button;
+/// Theme parameters exposed by the Telegram client.
 pub mod theme;
+/// User data and contact/permission requests.
 pub mod user;
+/// Viewport dimensions and expansion state.
 pub mod viewport;

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,16 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+/// Global [`context::TelegramContext`] holding parsed init data, theme
+/// parameters and the raw init-data string for the current Mini App session.
 pub mod context;
+/// SDK initialization routines that populate the global context from the
+/// running Telegram WebApp environment.
 pub mod init;
+/// Fallible accessors for the global context that return a
+/// [`wasm_bindgen::JsValue`] error instead of an [`Option`] when the context is
+/// not initialized.
 pub mod safe_context;
+/// Strongly-typed representations of the Telegram WebApp `initData`,
+/// launch parameters, theme parameters and related payload structures.
 pub mod types;

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -12,8 +12,14 @@ use super::types::{
 /// Global context of the Telegram Mini App, initialized once per app session.
 #[derive(Clone)]
 pub struct TelegramContext {
+    /// Parsed and validated `initData` describing the current user, chat and
+    /// session of the Mini App.
     pub init_data:     TelegramInitData,
+    /// Theme parameters reported by `Telegram.WebApp.themeParams` at
+    /// initialization time.
     pub theme_params:  TelegramThemeParams,
+    /// Original URL-encoded `initData` string, retained for server-side
+    /// signature validation.
     pub raw_init_data: String
 }
 

--- a/src/core/safe_context.rs
+++ b/src/core/safe_context.rs
@@ -5,6 +5,16 @@ use wasm_bindgen::JsValue;
 
 use crate::core::context::TelegramContext;
 
+/// Accesses the global [`TelegramContext`] and applies `f` to it.
+///
+/// This is the fallible counterpart to [`TelegramContext::get`]: instead of
+/// returning [`None`] when the context has not been initialized, it returns a
+/// [`JsValue`] error suitable for propagation across the WASM boundary.
+///
+/// # Errors
+///
+/// Returns `Err(JsValue)` if the global context has not been initialized via
+/// [`crate::core::init::init_sdk`].
 pub fn get_context<T>(f: impl FnOnce(&TelegramContext) -> T) -> Result<T, JsValue> {
     TelegramContext::get(f).ok_or_else(|| JsValue::from_str("TelegramContext is not initialized"))
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,15 +1,30 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+/// Chat descriptor found in the `chat` field of Telegram WebApp `initData`.
 pub mod chat;
+/// Parameters accepted by the `downloadFile` Telegram WebApp method.
 pub mod download_file_params;
+/// Parsed, strongly-typed view of the Telegram WebApp `initData` payload.
 pub mod init_data;
+/// Raw, string-based view of the Telegram WebApp `initData` payload used for
+/// signature validation before deserialization into richer types.
 pub mod init_data_internal;
+/// Launch parameters read from the Mini App URL query string
+/// (`tgWebApp*` parameters).
 pub mod launch_params;
+/// Message descriptor returned after sending data via `answerWebAppQuery`.
 pub mod sent_web_app_message;
+/// Telegram theme parameters exposed through `Telegram.WebApp.themeParams`.
 pub mod theme_params;
+/// Telegram user descriptor found in the `user` and `receiver` fields of
+/// `initData`.
 pub mod user;
+/// Data payload delivered to the bot when the Mini App calls `sendData`.
 pub mod web_app_data;
+/// Metadata describing a Mini App as configured on the bot side.
 pub mod web_app_info;
+/// Webhook status information returned by the Telegram Bot API.
 pub mod webhook_info;
+/// Service message signalling that the user allowed the bot to message them.
 pub mod write_access_allowed;

--- a/src/core/types/init_data_internal.rs
+++ b/src/core/types/init_data_internal.rs
@@ -3,17 +3,46 @@
 
 use serde::Deserialize;
 
+/// Raw, minimally-typed view of the Telegram WebApp `initData` payload.
+///
+/// The complex fields (`user`, `receiver`, `chat`) are kept as their original
+/// JSON-encoded strings so that the exact bytes can be used to verify the
+/// `hash` signature before they are parsed into richer types. This mirrors the
+/// structure of Telegram's `WebAppInitData` object as received on the client.
 #[derive(Deserialize)]
 pub struct TelegramInitDataInternal {
+    /// Unique query identifier of the Mini App session. Present when the app is
+    /// opened from an inline keyboard button and required to answer via
+    /// `answerWebAppQuery`.
     pub query_id:       Option<String>,
+    /// JSON-encoded string describing the current user, as delivered by
+    /// Telegram. Deserialized into a `WebAppUser` only after validation.
     pub user:           Option<String>,
+    /// JSON-encoded string describing the chat partner in a private chat the
+    /// bot was attached to when launched from the attachment menu.
     pub receiver:       Option<String>,
+    /// JSON-encoded string describing the chat the Mini App was launched from,
+    /// present for group, supergroup and channel chats.
     pub chat:           Option<String>,
+    /// Type of chat the Mini App was opened in: `"sender"`, `"private"`,
+    /// `"group"`, `"supergroup"` or `"channel"`.
     pub chat_type:      Option<String>,
+    /// Global identifier of the chat the Mini App was launched from, used to
+    /// validate that messages belong to the same chat.
     pub chat_instance:  Option<String>,
+    /// Value of the `startattach`/`start_param` deep-link parameter used to
+    /// launch the Mini App.
     pub start_param:    Option<String>,
+    /// Number of seconds after which a message can be sent via
+    /// `answerWebAppQuery`, used for rate limiting.
     pub can_send_after: Option<u64>,
+    /// Unix timestamp (in seconds) at which the `initData` was created and
+    /// signed by Telegram.
     pub auth_date:      u64,
+    /// Hex-encoded HMAC-SHA256 signature of the data-check string, used to
+    /// verify that the `initData` originates from Telegram.
     pub hash:           String,
+    /// Optional Ed25519 signature of the `initData`, provided for third-party
+    /// validation of the payload.
     pub signature:      Option<String>
 }

--- a/src/core/types/launch_params.rs
+++ b/src/core/types/launch_params.rs
@@ -1,11 +1,26 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+/// Launch parameters parsed from the Mini App URL query string.
+///
+/// Telegram appends a set of `tgWebApp*` query parameters to the URL it opens
+/// for the Mini App. This struct captures the subset used to determine the host
+/// platform, API version and launch options.
 #[derive(Debug, Clone)]
 pub struct LaunchParams {
+    /// Host platform the Mini App is running on, from `tgWebAppPlatform`
+    /// (e.g. `"android"`, `"ios"`, `"tdesktop"`, `"web"`).
     pub tg_web_app_platform:      Option<String>,
+    /// Version of the Telegram WebApp API supported by the host, from
+    /// `tgWebAppVersion`.
     pub tg_web_app_version:       Option<String>,
+    /// Deep-link start parameter passed to the Mini App, from
+    /// `tgWebAppStartParam`.
     pub tg_web_app_start_param:   Option<String>,
+    /// Whether the settings button should be shown, parsed from
+    /// `tgWebAppShowSettings` (`"1"` maps to `true`).
     pub tg_web_app_show_settings: Option<bool>,
+    /// Whether the Mini App was launched in inline mode from the bot, parsed
+    /// from `tgWebAppBotInline` (`"1"` maps to `true`).
     pub tg_web_app_bot_inline:    Option<bool>
 }

--- a/src/core/types/theme_params.rs
+++ b/src/core/types/theme_params.rs
@@ -197,6 +197,16 @@ impl TelegramThemeParams {
     }
 }
 
+/// Applies a default (empty) set of theme parameters to the document root.
+///
+/// This clears any previously set `--tg-theme-*` custom properties by writing
+/// only the values present in [`TelegramThemeParams::default`], which is none.
+/// It is exposed to JavaScript via `wasm_bindgen`.
+///
+/// # Errors
+///
+/// Returns `Err(JsValue)` if the global `window`/`document` objects are
+/// unavailable or the document root cannot be cast to an `HtmlElement`.
 #[wasm_bindgen]
 pub fn apply_default_theme() -> Result<(), JsValue> {
     let theme: TelegramThemeParams = Default::default();

--- a/src/dom/document.rs
+++ b/src/dom/document.rs
@@ -4,13 +4,24 @@
 use wasm_bindgen::JsValue;
 use web_sys::{Element, HtmlElement};
 
+/// Zero-sized handle providing convenient access to the current
+/// [`web_sys::Document`].
+///
+/// Each method resolves `window().document()` on demand, so no browser handles
+/// are stored. Re-exported as `Document`.
 pub struct Doc;
 
 impl Doc {
+    /// Returns the element with the given `id`, or `None` if it does not exist
+    /// or no document is available.
     pub fn get_element_by_id(&self, id: &str) -> Option<Element> {
         web_sys::window()?.document()?.get_element_by_id(id)
     }
 
+    /// Returns the first element matching the CSS `selector`.
+    ///
+    /// Returns `Ok(None)` when nothing matches, and `Err` when the document is
+    /// unavailable or the selector is invalid.
     pub fn query_selector(&self, selector: &str) -> Result<Option<Element>, JsValue> {
         web_sys::window()
             .and_then(|w| w.document())
@@ -18,6 +29,9 @@ impl Doc {
             .query_selector(selector)
     }
 
+    /// Creates a new element with the given `tag` name.
+    ///
+    /// Returns `Err` when the window or document is unavailable.
     pub fn create_element(&self, tag: &str) -> Result<Element, JsValue> {
         web_sys::window()
             .ok_or_else(|| JsValue::from_str("window not available"))?
@@ -26,6 +40,9 @@ impl Doc {
             .create_element(tag)
     }
 
+    /// Returns the document `<body>` element.
+    ///
+    /// Returns `Err` when the window, document, or body is unavailable.
     pub fn body(&self) -> Result<HtmlElement, JsValue> {
         web_sys::window()
             .ok_or_else(|| JsValue::from_str("window not available"))?

--- a/src/dom/element.rs
+++ b/src/dom/element.rs
@@ -4,24 +4,51 @@
 use wasm_bindgen::{JsCast, JsValue, closure::Closure};
 use web_sys::{Element, EventTarget, Node};
 
+/// Ergonomic extension methods for [`web_sys::Element`].
+///
+/// Provides concise helpers for common DOM manipulations (attributes, classes,
+/// text/HTML content, event listeners, and child insertion/removal) on top of
+/// the lower-level `web-sys` API.
 pub trait ElementExt {
+    /// Sets the `class` attribute, replacing any existing class list.
     fn set_class(&self, class: &str);
+    /// Sets the `id` attribute.
     fn set_id(&self, id: &str);
+    /// Replaces the element's text content with `text`.
     fn set_text(&self, text: &str);
+    /// Replaces the element's inner HTML with `html`.
     fn set_html(&self, html: &str) -> Result<(), JsValue>;
+    /// Sets attribute `attr` to `value`.
     fn set_attr(&self, attr: &str, value: &str) -> Result<(), JsValue>;
+    /// Returns the value of attribute `attr`, or `None` if it is absent.
     fn get_attr(&self, attr: &str) -> Option<String>;
+    /// Removes attribute `attr`.
     fn remove_attr(&self, attr: &str) -> Result<(), JsValue>;
+    /// Adds `class` to the `class` attribute if it is not already present.
     fn add_class(&self, class: &str) -> Result<(), JsValue>;
+    /// Removes `class` from the `class` attribute, dropping the attribute
+    /// entirely when no classes remain.
     fn remove_class(&self, class: &str) -> Result<(), JsValue>;
+    /// Adds `class` if absent, or removes it if present.
     fn toggle_class(&self, class: &str) -> Result<(), JsValue>;
+    /// Returns `true` if the `class` attribute contains `class` as a whole
+    /// token.
     fn has_class(&self, class: &str) -> bool;
+    /// Attaches `handler` as a listener for `event`.
+    ///
+    /// The underlying closure is leaked so the listener remains valid for the
+    /// lifetime of the element.
     fn on<F>(&self, event: &str, handler: F) -> Result<(), JsValue>
     where
         F: FnMut(web_sys::Event) + 'static;
+    /// Appends `child` as the last child of this element.
     fn append(&self, child: &Element) -> Result<(), JsValue>;
+    /// Inserts `child` as the first child of this element, or appends it when
+    /// the element has no children.
     fn prepend(&self, child: &Element) -> Result<(), JsValue>;
+    /// Detaches this element from its parent; a no-op when it has no parent.
     fn remove(&self) -> Result<(), JsValue>;
+    /// Removes all child nodes of this element.
     fn clear(&self);
 }
 

--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+//! Thin ergonomic wrappers over `web-sys` for DOM access.
+//!
+//! Provides a [`Document`] handle for resolving the current document and an
+//! [`ElementExt`] trait with convenience methods for manipulating elements.
+
+/// Document access helpers.
 pub mod document;
+/// Element extension trait.
 pub mod element;
 
 pub use document::Doc as Document;

--- a/src/leptos.rs
+++ b/src/leptos.rs
@@ -1,11 +1,18 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+/// [`back_button::BackButton`] component driving `WebApp.BackButton`.
 pub mod back_button;
+/// [`bottom_button::BottomButton`] component driving the main/secondary button.
 pub mod bottom_button;
+/// [`safe_area::use_safe_area`] hook exposing safe-area insets reactively.
 pub mod safe_area;
+/// [`settings_button::SettingsButton`] component driving
+/// `WebApp.SettingsButton`.
 pub mod settings_button;
+/// [`theme::use_theme`] hook exposing Telegram theme parameters reactively.
 pub mod theme;
+/// [`viewport::use_viewport`] hook exposing viewport size and state reactively.
 pub mod viewport;
 
 pub use back_button::BackButton;

--- a/src/leptos/back_button.rs
+++ b/src/leptos/back_button.rs
@@ -39,8 +39,12 @@ thread_local! {
 /// ```
 #[component]
 pub fn BackButton<F>(
-    #[prop(into)] visible: Signal<bool>,
-    #[prop(optional)] on_click: Option<F>
+    /// Reactive flag controlling whether the back button is shown.
+    #[prop(into)]
+    visible: Signal<bool>,
+    /// Optional callback invoked when the back button is clicked.
+    #[prop(optional)]
+    on_click: Option<F>
 ) -> impl IntoView
 where
     F: Fn() + Clone + 'static

--- a/src/leptos/bottom_button.rs
+++ b/src/leptos/bottom_button.rs
@@ -50,11 +50,21 @@ thread_local! {
 /// ```
 #[component]
 pub fn BottomButton<F>(
-    #[prop(into)] text: Signal<String>,
-    #[prop(optional, into)] color: Option<Signal<String>>,
-    #[prop(optional, into)] text_color: Option<Signal<String>>,
-    #[prop(optional)] on_click: Option<F>,
-    #[prop(default = WebBottomButton::Main)] button: WebBottomButton
+    /// Reactive text label displayed on the button.
+    #[prop(into)]
+    text: Signal<String>,
+    /// Optional reactive background color as a `#RRGGBB` hex string.
+    #[prop(optional, into)]
+    color: Option<Signal<String>>,
+    /// Optional reactive text color as a `#RRGGBB` hex string.
+    #[prop(optional, into)]
+    text_color: Option<Signal<String>>,
+    /// Optional callback invoked when the button is clicked.
+    #[prop(optional)]
+    on_click: Option<F>,
+    /// Which bottom button to control; defaults to the main button.
+    #[prop(default = WebBottomButton::Main)]
+    button: WebBottomButton
 ) -> impl IntoView
 where
     F: Fn() + Clone + 'static

--- a/src/leptos/settings_button.rs
+++ b/src/leptos/settings_button.rs
@@ -39,8 +39,12 @@ thread_local! {
 /// ```
 #[component]
 pub fn SettingsButton<F>(
-    #[prop(into)] visible: Signal<bool>,
-    #[prop(optional)] on_click: Option<F>
+    /// Reactive flag controlling whether the settings button is shown.
+    #[prop(into)]
+    visible: Signal<bool>,
+    /// Optional callback invoked when the settings button is clicked.
+    #[prop(optional)]
+    on_click: Option<F>
 ) -> impl IntoView
 where
     F: Fn() + Clone + 'static

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,32 @@
+#![warn(missing_docs)]
 // SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
-
 #![doc = include_str!("../README.md")]
 #![cfg_attr(all(docsrs, has_doc_cfg), feature(doc_cfg))]
 #![cfg_attr(all(docsrs, not(has_doc_cfg), has_doc_auto_cfg), feature(doc_auto_cfg))]
 
+/// High-level, ergonomic wrappers over the Telegram WebApp JavaScript API.
 pub mod api;
+/// Core primitives: launch parameters, init data, theme parameters and the
+/// global [`core::context::TelegramContext`].
 pub mod core;
+/// Thin helpers for interacting with the browser DOM from WebAssembly.
 pub mod dom;
+/// Logging helpers that forward messages to the browser console.
 pub mod logger;
 
 #[cfg(feature = "mock")]
 pub mod mock;
+/// Utility helpers, including environment detection for the Telegram WebApp.
 pub mod utils;
+/// Safe Rust bindings for `window.Telegram.WebApp` and its sub-objects.
 pub mod webapp;
 #[cfg(feature = "macros")]
 pub use inventory;
 pub use webapp::TelegramWebApp;
 #[cfg(feature = "macros")]
 mod macros;
+/// Registry of routable pages collected via the `#[page]` macro.
 #[cfg(feature = "macros")]
 pub mod pages;
 #[cfg(feature = "macros")]
@@ -26,8 +34,10 @@ pub mod pages;
 pub use crate::macros::*;
 pub mod router;
 
+/// Yew components and hooks for building Telegram mini apps.
 #[cfg(feature = "yew")]
 pub mod yew;
 
+/// Leptos components and hooks for building Telegram mini apps.
 #[cfg(feature = "leptos")]
 pub mod leptos;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,7 +1,17 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+//! Mocking utilities for running the SDK outside a real Telegram client.
+//!
+//! Provides configuration, sample data, initialization helpers and utilities
+//! to simulate the Telegram WebApp environment during local development and
+//! testing.
+
+/// Configuration types for describing the mocked Telegram environment.
 pub mod config;
+/// Sample data structures used to populate the mocked environment.
 pub mod data;
+/// Initialization helpers that install the mocked environment.
 pub mod init;
+/// Helper utilities for building and serializing mock data.
 pub mod utils;

--- a/src/mock/config.rs
+++ b/src/mock/config.rs
@@ -13,26 +13,55 @@ use super::data::MockTelegramUser;
 /// Configuration for mocking Telegram environment.
 #[derive(Default, Deserialize)]
 pub struct MockTelegramConfig {
+    /// Mocked Telegram user to expose through `initDataUnsafe`.
     pub user: Option<MockTelegramUser>,
+    /// Unix timestamp (as a string) when the init data was authorized.
     pub auth_date: Option<String>,
+    /// Hash used to verify the authenticity of the init data.
     pub hash: Option<String>,
+    /// Unique identifier of the WebApp query, used to answer inline queries.
     pub query_id: Option<String>,
+    /// Value mocking the `bg_color` theme parameter (hex color string).
     pub bg_color: Option<String>,
+    /// Value mocking the `text_color` theme parameter (hex color string).
     pub text_color: Option<String>,
+    /// Value mocking the `hint_color` theme parameter (hex color string).
     pub hint_color: Option<String>,
+    /// Value mocking the `link_color` theme parameter (hex color string).
     pub link_color: Option<String>,
+    /// Value mocking the `button_color` theme parameter (hex color string).
     pub button_color: Option<String>,
+    /// Value mocking the `button_text_color` theme parameter (hex color
+    /// string).
     pub button_text_color: Option<String>,
+    /// Value mocking the `secondary_bg_color` theme parameter (hex color
+    /// string).
     pub secondary_bg_color: Option<String>,
+    /// Value mocking the `header_bg_color` theme parameter (hex color string).
     pub header_bg_color: Option<String>,
+    /// Value mocking the `bottom_bar_bg_color` theme parameter (hex color
+    /// string).
     pub bottom_bar_bg_color: Option<String>,
+    /// Value mocking the `accent_text_color` theme parameter (hex color
+    /// string).
     pub accent_text_color: Option<String>,
+    /// Value mocking the `section_bg_color` theme parameter (hex color string).
     pub section_bg_color: Option<String>,
+    /// Value mocking the `section_header_text_color` theme parameter (hex color
+    /// string).
     pub section_header_text_color: Option<String>,
+    /// Value mocking the `section_separator_color` theme parameter (hex color
+    /// string).
     pub section_separator_color: Option<String>,
+    /// Value mocking the `subtitle_text_color` theme parameter (hex color
+    /// string).
     pub subtitle_text_color: Option<String>,
+    /// Value mocking the `destructive_text_color` theme parameter (hex color
+    /// string).
     pub destructive_text_color: Option<String>,
+    /// Mocked platform identifier (e.g. `android`, `ios`, `tdesktop`).
     pub platform: Option<String>,
+    /// Mocked Telegram WebApp version string (e.g. `7.0`).
     pub version: Option<String>
 }
 

--- a/src/mock/data.rs
+++ b/src/mock/data.rs
@@ -3,13 +3,21 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Mocked Telegram user, mirroring the Telegram WebApp `WebAppUser` object.
 #[derive(Serialize, Deserialize, Default)]
 pub struct MockTelegramUser {
+    /// Unique identifier of the user.
     pub id:                 u64,
+    /// First name of the user.
     pub first_name:         String,
+    /// Last name of the user, if set.
     pub last_name:          Option<String>,
+    /// Telegram username, without the leading `@`, if set.
     pub username:           Option<String>,
+    /// IETF language tag of the user's language (e.g. `en`), if known.
     pub language_code:      Option<String>,
+    /// Whether the user has a Telegram Premium subscription.
     pub is_premium:         Option<bool>,
+    /// Whether the user allowed the bot to message them in private chat.
     pub allows_write_to_pm: Option<bool>
 }

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -6,7 +6,9 @@ use inventory::collect;
 /// Represents a single routable page.
 #[derive(Copy, Clone)]
 pub struct Page {
+    /// URL path this page is mounted at.
     pub path:    &'static str,
+    /// Callback rendering the page when its path is matched.
     pub handler: fn()
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+/// Detection of the Telegram WebApp runtime environment.
 pub mod check_env;

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -12,6 +12,8 @@ mod lifecycle;
 mod navigation;
 mod permissions;
 mod theme;
+/// Public data types shared across the WebApp bindings: button descriptors,
+/// button parameters, link/close options and event handles.
 pub mod types;
 mod viewport;
 

--- a/src/webapp/lifecycle.rs
+++ b/src/webapp/lifecycle.rs
@@ -254,6 +254,17 @@ impl TelegramWebApp {
             .unwrap_or(false)
     }
 
+    /// Returns whether the mini app is expanded to its maximum available
+    /// height.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use telegram_webapp_sdk::webapp::TelegramWebApp;
+    ///
+    /// if let Some(app) = TelegramWebApp::instance() {
+    ///     let _ = app.is_expanded();
+    /// }
+    /// ```
     pub fn is_expanded(&self) -> bool {
         Reflect::get(&self.inner, &"isExpanded".into())
             .ok()

--- a/src/webapp/types.rs
+++ b/src/webapp/types.rs
@@ -238,16 +238,22 @@ impl SafeAreaInset {
 /// ```
 #[derive(Debug, Default, Serialize)]
 pub struct BottomButtonParams<'a> {
+    /// Text label displayed on the button.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text:                 Option<&'a str>,
+    /// Button background color as a `#RRGGBB` hex string.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color:                Option<&'a str>,
+    /// Button text color as a `#RRGGBB` hex string.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_color:           Option<&'a str>,
+    /// Whether the button is active (tappable) rather than disabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_active:            Option<bool>,
+    /// Whether the button is visible.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_visible:           Option<bool>,
+    /// Whether the button plays a shimmering shine animation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_shine_effect:     Option<bool>,
     /// Custom emoji ID for the button icon (Bot API 9.5+).
@@ -290,8 +296,10 @@ pub struct BottomButtonParams<'a> {
 /// ```
 #[derive(Debug, Default, Serialize)]
 pub struct SecondaryButtonParams<'a> {
+    /// Parameters shared with the main button (text, colors, visibility, …).
     #[serde(flatten)]
     pub common:   BottomButtonParams<'a>,
+    /// Placement of the secondary button relative to the main button.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<SecondaryButtonPosition>
 }
@@ -312,6 +320,8 @@ pub struct SecondaryButtonParams<'a> {
 /// ```
 #[derive(Debug, Default, Serialize)]
 pub struct OpenLinkOptions {
+    /// If `true`, attempts to open the link in Instant View mode when
+    /// supported.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub try_instant_view: Option<bool>,
     /// Preferred external browser (Bot API 7.6+). Pass values like `"chrome"`,

--- a/src/yew.rs
+++ b/src/yew.rs
@@ -8,11 +8,18 @@ use yew::prelude::{hook, use_effect, use_state};
 
 use crate::core::{context::TelegramContext, safe_context::get_context};
 
+/// [`back_button::BackButton`] component driving `WebApp.BackButton`.
 pub mod back_button;
+/// [`bottom_button::BottomButton`] component driving the main/secondary button.
 pub mod bottom_button;
+/// [`safe_area::use_safe_area`] hook exposing safe-area insets reactively.
 pub mod safe_area;
+/// [`settings_button::SettingsButton`] component driving
+/// `WebApp.SettingsButton`.
 pub mod settings_button;
+/// [`theme::use_theme`] hook exposing Telegram theme parameters reactively.
 pub mod theme;
+/// [`viewport::use_viewport`] hook exposing viewport size and state reactively.
 pub mod viewport;
 
 pub use back_button::BackButton;


### PR DESCRIPTION
Closes #259

Adds crate-level `#![warn(missing_docs)]` and documents every previously-undocumented public item (155 items across ~25 files) so docs.rs is complete and future gaps are surfaced.

Docs describe actual behavior (Telegram WebApp semantics for init-data/theme/config types, DOM operations for `dom` helpers, component props for Leptos/Yew, covered API area for each `api` submodule) — no filler. Only `///`/`//!` used; no code or signatures changed.

Verified: clean `cargo build --all-features` emits 0 missing-documentation warnings, clippy (`-D warnings`) clean, fmt clean, tests green (183), `reuse lint` passes.