### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.1...v0.11.2) - 2026-07-08
+
+### Documentation
+
+- enforce missing_docs and document public API ([#260](https://github.com/RAprogramm/telegram-webapp-sdk/issues/260))
+
 ## [0.11.1](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.0...v0.11.1) - 2026-07-08
 
 ### CI/CD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.11.1"
+version = "0.11.2"
 rust-version = "1.96"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION



## 🤖 New release

* `telegram-webapp-sdk`: 0.11.1 -> 0.11.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.2](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.1...v0.11.2) - 2026-07-08

### Documentation

- enforce missing_docs and document public API ([#260](https://github.com/RAprogramm/telegram-webapp-sdk/issues/260))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).