### PR TITLE
chore: release v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.2...v0.11.3) - 2026-07-19
+
+### CI/CD
+
+- *(ci)* bump taiki-e/install-action from 2.82.10 to 2.83.2 ([#263](https://github.com/RAprogramm/telegram-webapp-sdk/issues/263))
+
+### Dependencies
+
+- deps(cargo)(deps): bump regex ([#262](https://github.com/RAprogramm/telegram-webapp-sdk/issues/262))
+
 ## [0.11.2](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.1...v0.11.2) - 2026-07-08
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.11.2"
+version = "0.11.3"
 rust-version = "1.96"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION



## 🤖 New release

* `telegram-webapp-sdk`: 0.11.2 -> 0.11.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.3](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.2...v0.11.3) - 2026-07-19

### CI/CD

- *(ci)* bump taiki-e/install-action from 2.82.10 to 2.83.2 ([#263](https://github.com/RAprogramm/telegram-webapp-sdk/issues/263))

### Dependencies

- deps(cargo)(deps): bump regex ([#262](https://github.com/RAprogramm/telegram-webapp-sdk/issues/262))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).