### PR TITLE
chore: release v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.3...v0.11.4) - 2026-08-23
+
+### CI/CD
+
+- *(ci)* bump release-plz/action from 0.5.130 to 0.5.131 ([#267](https://github.com/RAprogramm/telegram-webapp-sdk/issues/267))
+- *(ci)* bump actions/checkout from 7.0.0 to 7.0.1 ([#269](https://github.com/RAprogramm/telegram-webapp-sdk/issues/269))
+- *(ci)* bump Swatinem/rust-cache ([#274](https://github.com/RAprogramm/telegram-webapp-sdk/issues/274))
+- *(ci)* bump taiki-e/install-action from 2.83.2 to 2.85.13 ([#275](https://github.com/RAprogramm/telegram-webapp-sdk/issues/275))
+
+### Dependencies
+
+- deps(cargo)(deps): bump the cargo-minor-patch group across 2 directories with 6 updates ([#268](https://github.com/RAprogramm/telegram-webapp-sdk/issues/268))
+
 ## [0.11.3](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.2...v0.11.3) - 2026-07-19
 
 ### CI/CD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-webapp-sdk"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "inventory",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-webapp-sdk"
-version = "0.11.3"
+version = "0.11.4"
 rust-version = "1.96"
 edition = "2024"
 description = "Telegram WebApp SDK for Rust"


### PR DESCRIPTION



## 🤖 New release

* `telegram-webapp-sdk`: 0.11.3 -> 0.11.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.4](https://github.com/RAprogramm/telegram-webapp-sdk/compare/v0.11.3...v0.11.4) - 2026-08-23

### CI/CD

- *(ci)* bump release-plz/action from 0.5.130 to 0.5.131 ([#267](https://github.com/RAprogramm/telegram-webapp-sdk/issues/267))
- *(ci)* bump actions/checkout from 7.0.0 to 7.0.1 ([#269](https://github.com/RAprogramm/telegram-webapp-sdk/issues/269))
- *(ci)* bump Swatinem/rust-cache ([#274](https://github.com/RAprogramm/telegram-webapp-sdk/issues/274))
- *(ci)* bump taiki-e/install-action from 2.83.2 to 2.85.13 ([#275](https://github.com/RAprogramm/telegram-webapp-sdk/issues/275))

### Dependencies

- deps(cargo)(deps): bump the cargo-minor-patch group across 2 directories with 6 updates ([#268](https://github.com/RAprogramm/telegram-webapp-sdk/issues/268))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.11.4.
  * Applied routine maintenance updates to improve build and delivery reliability.
  * Updated supporting components to incorporate maintenance and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->